### PR TITLE
Removal of Verizon and Yahoo

### DIFF
--- a/Code-of-Conduct.md
+++ b/Code-of-Conduct.md
@@ -1,16 +1,14 @@
-# Verizon Media Open Source Code of Conduct
+# ASHIRT Code of Conduct
 
 ## Summary
 This Code of Conduct is our way to encourage good behavior and discourage bad behavior in our open source projects. We invite participation from many people to bring different perspectives to our projects. We will do our part to foster a welcoming and professional environment free of harassment. We expect participants to communicate professionally and thoughtfully during their involvement with this project. 
-
-Participants may lose their good standing by engaging in misconduct. For example: insulting, threatening, or conveying unwelcome sexual content. We ask participants who observe conduct issues to report the incident directly to the project's Response Team at opensource-conduct@verizonmedia.com. Verizon Media will assign a respondent to address the issue. We may remove harassers from this project. 
 
 This code does not replace the terms of service or acceptable use policies of the websites used to support this project. We acknowledge that participants may be subject to additional conduct terms based on their employment which may govern their online expressions.
 
 ## Details
 This Code of Conduct makes our expectations of participants in this community explicit.
 * We forbid harassment and abusive speech within this community.
-* We request participants to report misconduct to the project’s Response Team.
+* We request participants to report misconduct to the project’s moderation team on discord.
 * We urge participants to refrain from using discussion forums to play out a fight.
 
 ### Expected Behaviors
@@ -25,7 +23,7 @@ We expect participants in this community to conduct themselves professionally. S
 * **Leave with class.** When you wish to resign from participating in this project for any reason, you are free to fork the code and create a competitive project. Open Source explicitly allows this. Your exit should not be dramatic or bitter. 
 
 ### Unacceptable Behaviors
-Participants remain in good standing when they do not engage in misconduct or harassment (some examples follow). We do not list all forms of harassment, nor imply some forms of harassment are not worthy of action. Any participant who *feels* harassed or *observes* harassment, should report the incident to the Response Team. 
+Participants remain in good standing when they do not engage in misconduct or harassment (some examples follow). We do not list all forms of harassment, nor imply some forms of harassment are not worthy of action. Any participant who *feels* harassed or *observes* harassment, should report the incident to the moderation team.
 * **Don't be a bigot.** Calling out project members by their identity or background in a negative or insulting manner. This includes, but is not limited to, slurs or insinuations related to protected or suspect classes e.g. race, color, citizenship, national origin, political belief, religion, sexual orientation, gender identity and expression, age, size, culture, ethnicity, genetic features, language, profession, national minority status, mental or physical ability.
 * **Don't insult.** Insulting remarks about a person’s lifestyle practices.
 * **Don't dox.** Revealing private information about other participants without explicit permission.
@@ -35,18 +33,10 @@ Participants remain in good standing when they do not engage in misconduct or ha
 * **Don't disrupt.** Sustained disruptions in a discussion.
 
 ### Reporting Issues
-If you experience or witness misconduct, or have any other concerns about the conduct of members of this project, please report it by contacting our Response Team at opensource-conduct@verizonmedia.com who will handle your report with discretion. Your report should include:
+If you experience or witness misconduct, or have any other concerns about the conduct of members of this project, please report it by contacting a moderator on discord who will handle your report with discretion. Your report should include:
 * Your preferred contact information. We cannot process anonymous reports.
 * Names (real or usernames) of those involved in the incident.
 * Your account of what occurred, and if the incident is ongoing. Please provide links to or transcripts of the publicly available records (e.g. a mailing list archive or a public IRC logger), so that we can review it.
 * Any additional information that may be helpful to achieve resolution.
 
-After filing a report, a representative will contact you directly to review the incident and ask additional questions. If a member of the Verizon Media Response Team is named in an incident report, that member will be recused from handling your incident. If the complaint originates from a member of the Response Team, it will be addressed by a different member of the Response Team. We will consider reports to be confidential for the purpose of protecting victims of abuse. 
-
-### Scope
-Verizon Media will assign a Response Team member with admin rights on the project and legal rights on the project copyright. The Response Team is empowered to restrict some privileges to the project as needed. Since this project is governed by an open source license, any participant may fork the code under the terms of the project license. The Response Team’s goal is to preserve the project if possible, and will restrict or remove participation from those who disrupt the project. 
-
-This code does not replace the terms of service or acceptable use policies that are provided by the websites used to support this community. Nor does this code apply to communications or actions that take place outside of the context of this community. Many participants in this project are also subject to codes of conduct based on their employment. This code is a social-contract that informs participants of our social expectations. It is not a terms of service or legal contract.
-
-## License and Acknowledgment. 
-This text is shared under the [CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/). This code is based on a study conducted by the [TODO Group](https://todogroup.org/) of many codes used in the open source community. If you have feedback about this code, contact our Response Team at the address listed above. 
+After filing a report, a representative will contact you directly to review the incident and ask additional questions. If a member of the moderation team is named in an incident report, that member will be recused from handling your incident. If the complaint originates from a member of the moderation team, it will be addressed by a different member of the moderation team. We will consider reports to be confidential for the purpose of protecting victims of abuse.

--- a/Contributing.md
+++ b/Contributing.md
@@ -23,4 +23,4 @@ We only seek to accept code that you are authorized to contribute to the project
 
 ## Code of Conduct
 
-We encourage inclusive and professional interactions on our project. We welcome everyone to open an issue, improve the documentation, report bug or ssubmit a pull request. By participating in this project, you agree to abide by the [Verizon Media Code of Conduct](Code-of-Conduct.md). If you feel there is a conduct issue related to this project, please raise it per the Code of Conduct process and we will address it.
+We encourage inclusive and professional interactions on our project. We welcome everyone to open an issue, improve the documentation, report bug or ssubmit a pull request. By participating in this project, you agree to abide by the [Code of Conduct](Code-of-Conduct.md). If you feel there is a conduct issue related to this project, please raise it per the Code of Conduct process and we will address it.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2020 Verizon Media
+Copyright 2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/cmd/aterm/appdialogs/errors.go
+++ b/cmd/aterm/appdialogs/errors.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package appdialogs
 
 import (

--- a/cmd/aterm/appdialogs/menu_state.go
+++ b/cmd/aterm/appdialogs/menu_state.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package appdialogs
 
 import (

--- a/cmd/aterm/climain.go
+++ b/cmd/aterm/climain.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package main
 
 import (

--- a/cmd/aterm/recording/ptystate.go
+++ b/cmd/aterm/recording/ptystate.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package recording
 
 import (

--- a/cmd/aterm/recording/start_recording.go
+++ b/cmd/aterm/recording/start_recording.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package recording
 
 import (

--- a/common/event.go
+++ b/common/event.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package common
 
 import (

--- a/dialog/loading_animation.go
+++ b/dialog/loading_animation.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package dialog
 
 import (

--- a/dialog/options.go
+++ b/dialog/options.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package dialog
 
 import (

--- a/dialog/prompt.go
+++ b/dialog/prompt.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package dialog
 
 import (

--- a/dialog/searchers.go
+++ b/dialog/searchers.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package dialog
 
 import "strings"

--- a/dialog/selecters.go
+++ b/dialog/selecters.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package dialog
 
 import (

--- a/dialog/yesno_dialog.go
+++ b/dialog/yesno_dialog.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package dialog
 
 import (

--- a/eventers/event_writer.go
+++ b/eventers/event_writer.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package eventers
 
 import (

--- a/eventers/event_writer_test.go
+++ b/eventers/event_writer_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package eventers
 
 import (

--- a/fancy/styles.go
+++ b/fancy/styles.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package fancy
 
 import (

--- a/formatters/asciicast_formatter.go
+++ b/formatters/asciicast_formatter.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package formatters
 
 import (

--- a/formatters/asciicast_formatter_test.go
+++ b/formatters/asciicast_formatter_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package formatters
 
 import (

--- a/formatters/asciicast_types.go
+++ b/formatters/asciicast_types.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package formatters
 
 // ASCIICastHeader is a structure for representing Asciinema formatted files. See here:

--- a/formatters/formatter.go
+++ b/formatters/formatter.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package formatters
 
 import "github.com/theparanoids/aterm/common"

--- a/formatters/metadata.go
+++ b/formatters/metadata.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package formatters
 
 import "fmt"

--- a/network/common.go
+++ b/network/common.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network
 
 import (

--- a/network/common_test.go
+++ b/network/common_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network
 
 import (

--- a/network/get_operations.go
+++ b/network/get_operations.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network
 
 import (

--- a/network/get_operations_test.go
+++ b/network/get_operations_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network_test
 
 import (

--- a/network/tagging.go
+++ b/network/tagging.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network
 
 import (

--- a/network/test_helpers_test.go
+++ b/network/test_helpers_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network_test
 
 import (

--- a/network/upload.go
+++ b/network/upload.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network
 
 import (

--- a/network/upload_test.go
+++ b/network/upload_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package network_test
 
 import (

--- a/recorders/buffered_recorder.go
+++ b/recorders/buffered_recorder.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package recorders
 
 import (

--- a/recorders/buffered_recorder_test.go
+++ b/recorders/buffered_recorder_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package recorders
 
 import (

--- a/recorders/recorder.go
+++ b/recorders/recorder.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package recorders
 
 import (

--- a/recorders/streaming_recorder.go
+++ b/recorders/streaming_recorder.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package recorders
 
 import (

--- a/recorders/streaming_recorder_test.go
+++ b/recorders/streaming_recorder_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package recorders
 
 import (

--- a/systemstate/state.go
+++ b/systemstate/state.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package systemstate
 
 type SystemState struct {

--- a/write/file_like.go
+++ b/write/file_like.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write
 
 // FileLike is a small interface to act like an os.File, for the purposes of StreamingFileWriter,

--- a/write/helpers.go
+++ b/write/helpers.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write
 
 import (

--- a/write/nil_term_writer.go
+++ b/write/nil_term_writer.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write
 
 import (

--- a/write/saving_term_writer.go
+++ b/write/saving_term_writer.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write
 
 import (

--- a/write/saving_term_writer_test.go
+++ b/write/saving_term_writer_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write_test
 
 import (

--- a/write/streaming_file_writer.go
+++ b/write/streaming_file_writer.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write
 
 import (

--- a/write/streaming_file_writer_test.go
+++ b/write/streaming_file_writer_test.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write
 
 import (

--- a/write/terminal_writer.go
+++ b/write/terminal_writer.go
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of the MIT. See LICENSE file in project root for terms.
-
 package write
 
 import (


### PR DESCRIPTION
This PR removes language related to Verizon Media or Yahoo. Per-file copyright and license information is removed in favor of the project LICENSE file.