### PR TITLE
Fix config file permissions to restrict credential access

### DIFF
--- a/cmd/aterm/config/config.go
+++ b/cmd/aterm/config/config.go
@@ -162,8 +162,8 @@ func CloneLoadedConfigAsOverrides() TermRecorderConfigOverrides {
 }
 
 func (t *TermRecorderConfig) WriteConfigToFile(configFilePath string) error {
-	os.MkdirAll(path.Dir(configFilePath), 0755)
-	outFile, err := os.Create(configFilePath)
+	os.MkdirAll(path.Dir(configFilePath), 0700)
+	outFile, err := os.OpenFile(configFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return errors.Wrap(err, "Unable to create config file")
 	}


### PR DESCRIPTION
Change config directory permissions from 0755 to 0700 and config file permissions from 0666 (via os.Create) to 0600 (via os.OpenFile) to prevent other local users from reading ASHIRT API credentials.

Addresses: F-01 (CWE-312)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.