### PR TITLE
Limit HTTP response body reads to 10MB

### DIFF
--- a/network/common.go
+++ b/network/common.go
@@ -16,6 +16,8 @@ import (
 
 var client = &http.Client{}
 
+const maxResponseSize = 10 * 1024 * 1024
+
 var apiURL string
 var accessKey string
 var secretKey []byte
@@ -76,7 +78,7 @@ func evaluateResponseStatusCode(code int) error {
 }
 
 func readResponseBody(container interface{}, body io.Reader) error {
-	content, err := ioutil.ReadAll(body)
+	content, err := ioutil.ReadAll(io.LimitReader(body, maxResponseSize))
 	if err != nil {
 		return errors.Wrap(err, "Unable to read response")
 	}

--- a/network/upload.go
+++ b/network/upload.go
@@ -85,7 +85,7 @@ func UploadToAshirt(ui UploadInput) (*dtos.Evidence, error) {
 	}
 	if resp.StatusCode != 201 {
 		defer resp.Body.Close()
-		raw, err := ioutil.ReadAll(resp.Body)
+		raw, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 		if err != nil {
 			return nil, errors.Wrap(err, "Server did not accept request: Unable to read error response")
 		}


### PR DESCRIPTION
Wrap ioutil.ReadAll calls with io.LimitReader to prevent memory exhaustion from a malicious or misbehaving server response.

Addresses: F-05 (CWE-400)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.