### PR TITLE
Restrict recording file and directory permissions

### DIFF
--- a/write/helpers.go
+++ b/write/helpers.go
@@ -11,7 +11,7 @@ import (
 // This file will be prefixed with "recording_". Under the hood, uses ioutil.TempFile in this case.
 func NewFile(dir, name string) (*os.File, error) {
 	var realFile *os.File
-	err := os.MkdirAll(dir, 0775)
+	err := os.MkdirAll(dir, 0700)
 	if err != nil {
 		return nil, err
 	}
@@ -20,7 +20,7 @@ func NewFile(dir, name string) (*os.File, error) {
 		realFile, err = ioutil.TempFile(dir, "recording_*.cast")
 	} else {
 		filename := filepath.Join(dir, name)
-		realFile, err = os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		realFile, err = os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
 	}
 
 	return realFile, err


### PR DESCRIPTION
Change recording directory from 0775 to 0700 and recording files from 0644 to 0600. Terminal recordings may contain sensitive session data and should not be readable by other local users.

Addresses: F-07 (CWE-732)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.