### PR TITLE
Strip credential env vars from PTY sub-shell environment

### DIFF
--- a/cmd/aterm/recording/ptystate.go
+++ b/cmd/aterm/recording/ptystate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/creack/pty"
@@ -48,6 +49,7 @@ func (t *PtyTracker) Run(shell string) error {
 	defer t.close()
 
 	c := exec.Command(shell)
+	c.Env = filterSensitiveEnv(os.Environ())
 	var err error
 	t.Pty, err = pty.Start(c)
 	if err != nil {
@@ -73,6 +75,17 @@ func (t *PtyTracker) close() {
 	if t.Pty != nil {
 		t.Pty.Close()
 	}
+}
+
+func filterSensitiveEnv(environ []string) []string {
+	filtered := make([]string, 0, len(environ))
+	for _, env := range environ {
+		if !strings.HasPrefix(env, "ASHIRT_TERM_RECORDER_ACCESS_KEY=") &&
+			!strings.HasPrefix(env, "ASHIRT_TERM_RECORDER_SECRET_KEY=") {
+			filtered = append(filtered, env)
+		}
+	}
+	return filtered
 }
 
 func startResizeListener(ptmx *os.File) chan os.Signal {


### PR DESCRIPTION
Filter out ASHIRT_TERM_RECORDER_ACCESS_KEY and
ASHIRT_TERM_RECORDER_SECRET_KEY from the child process environment before spawning the PTY. Prevents credentials from being visible inside the recorded session and potentially captured in recordings.

Addresses: F-09 (CWE-214)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.