### PR TITLE
Sanitize filename in rename to prevent path traversal

### DIFF
--- a/cmd/aterm/appdialogs/upload_menu.go
+++ b/cmd/aterm/appdialogs/upload_menu.go
@@ -91,7 +91,7 @@ func renameRecording(metadata RecordingMetadata) RecordingMetadata {
 	} else if resp.Err != nil {
 		printline(fancy.Fatal("Unable to move file", resp.Err))
 	} else if resp.SafeValue() != originalName {
-		filename := resp.SafeValue()
+		filename := filepath.Base(resp.SafeValue())
 		if !strings.HasSuffix(filename, ".cast") {
 			filename += ".cast"
 		}


### PR DESCRIPTION
Use filepath.Base() to strip directory components from user-provided filename before joining with the recording directory. Prevents inputs like '../../etc/evil.cast' from moving files outside the intended directory.

Addresses: F-08 (CWE-22)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.