### PR TITLE
URL-encode operation slug in API path construction

### DIFF
--- a/network/tagging.go
+++ b/network/tagging.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"net/http"
+	"net/url"
 
 	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/aterm/errors"
@@ -14,7 +15,7 @@ import (
 func GetTags(operationSlug string) ([]dtos.Tag, error) {
 	var tags []dtos.Tag
 
-	resp, err := makeJSONRequest("GET", apiURL+"/operations/"+operationSlug+"/tags", http.NoBody)
+	resp, err := makeJSONRequest("GET", apiURL+"/operations/"+url.PathEscape(operationSlug)+"/tags", http.NoBody)
 	if err != nil {
 		return tags, errors.Append(err, ErrCannotConnect)
 	}
@@ -40,7 +41,7 @@ func CreateTag(operationSlug, name, colorName string) (*dtos.Tag, error) {
 		return nil, errors.Wrap(err, "Unable to create tag")
 	}
 
-	resp, err := makeJSONRequest("POST", apiURL+"/operations/"+operationSlug+"/tags", bytes.NewReader(content))
+	resp, err := makeJSONRequest("POST", apiURL+"/operations/"+url.PathEscape(operationSlug)+"/tags", bytes.NewReader(content))
 
 	if err != nil {
 		return nil, errors.Append(err, ErrCannotConnect)

--- a/network/upload.go
+++ b/network/upload.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 
 	"github.com/theparanoids/ashirt-server/backend/dtos"
 	"github.com/theparanoids/aterm/errors"
@@ -39,7 +40,7 @@ const ErrCouldNotInitMsg = "Unable to initialize Request"
 // UploadToAshirt uploads a terminal recording to the AShirt service. The remote service must
 // be configured by calling network.SetBaseURL(string) before uploading.
 func UploadToAshirt(ui UploadInput) (*dtos.Evidence, error) {
-	url := apiURL + "/operations/" + ui.OperationSlug + "/evidence"
+	url := apiURL + "/operations/" + url.PathEscape(ui.OperationSlug) + "/evidence"
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	jsonTags, _ := json.Marshal(ui.TagIDs)


### PR DESCRIPTION
Apply url.PathEscape() to the operation slug before concatenating into URL paths. Prevents path traversal if a crafted slug is provided via CLI flag, env var, or config file.

Addresses: F-06 (CWE-20)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.