### PR TITLE
Move defer f.Close() after error check to prevent nil panic

### DIFF
--- a/cmd/aterm/config/config.go
+++ b/cmd/aterm/config/config.go
@@ -66,13 +66,13 @@ func ParseConfigNoOverrides() (TermRecorderConfig, error) {
 
 func parseConfigFile(cfg *TermRecorderConfig) error {
 	f, err := os.Open(ATermConfigPath())
-	defer f.Close()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return ErrConfigFileDoesNotExist
 		}
 		return errors.Wrap(err, "Unable to read config file")
 	}
+	defer f.Close()
 	return cfg.parseFileContent(f)
 }
 


### PR DESCRIPTION
If os.Open fails, f is nil and the deferred f.Close() would panic. Move the defer after the error check so it only runs when f is valid.

Addresses: F-13 (CWE-476)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.