### PR TITLE
fix: Add nil checks for newTag to prevent potential nil dereference

### DIFF
--- a/cmd/aterm/appdialogs/upload_menu.go
+++ b/cmd/aterm/appdialogs/upload_menu.go
@@ -232,12 +232,12 @@ func askForTags(operationSlug string, allTags []dtos.Tag, selectedTagIDs []int64
 			if err != nil {
 				if err == ErrCancelled {
 					printline("Tag creation cancelled")
-				} else if err == ErrAlreadyExists {
+				} else if err == ErrAlreadyExists && newTag != nil {
 					toggleValue(&selectedTagIDs, newTag.ID)
-				} else {
+				} else if err != ErrAlreadyExists {
 					printfln("Unable to create tag. Error: %v", err.Error())
 				}
-			} else {
+			} else if newTag != nil {
 				allTags = append(allTags, *newTag)
 				selectedTagIDs = append(selectedTagIDs, newTag.ID)
 			}


### PR DESCRIPTION
While askForNewTag currently returns a non-nil tag with ErrAlreadyExists, add defensive nil checks to guard against future changes that could break this assumption and cause a panic.

Addresses: F-15 (CWE-665)

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/aterm/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/aterm/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.