### PR TITLE
ASHIRT HMAC-SHA256 request signing (aterm-8tn.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,10 +64,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "avt",
+ "base64",
  "clap",
  "directories",
+ "hmac",
  "serde",
  "serde_yaml_ng",
+ "sha2",
  "thiserror",
 ]
 
@@ -79,6 +82,21 @@ checksum = "7179c44abe2ac36173d4713bfed24136e5988f005c7fe2c4fcde621d3d4d29b9"
 dependencies = [
  "rgb",
  "unicode-width",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -134,10 +152,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
+]
 
 [[package]]
 name = "directories"
@@ -188,6 +257,24 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "indexmap"
@@ -326,6 +413,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +459,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,13 @@ publish = false
 [dependencies]
 anyhow = "1.0.102"
 avt = { version = "0.18.0", optional = true }
+base64 = "0.22.1"
 clap = { version = "4.6.1", features = ["derive"] }
 directories = "6.0.0"
+hmac = "0.13.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml_ng = "0.10.0"
+sha2 = "0.11.0"
 thiserror = "2.0.18"
 
 [features]

--- a/src/ashirt/signing.rs
+++ b/src/ashirt/signing.rs
@@ -1,9 +1,34 @@
 //! ASHIRT request signing.
 //!
 //! ASHIRT authenticates API calls with an HMAC-SHA256 signature over a canonical
-//! representation of the request, sent in the `Authorization` header.
+//! representation of the request, sent in the `Authorization` header. This is a
+//! port of the Go `ashirt-server/signer` (see `network/common.go`) and MUST match
+//! the server byte-for-byte.
+//!
+//! The canonical request is:
+//!
+//! ```text
+//! METHOD \n REQUEST_URI \n DATE \n SHA256(body)
+//! ```
+//!
+//! where `REQUEST_URI` includes any query string, `DATE` is the RFC 1123 value of
+//! the request's `Date` header (in GMT), and `SHA256(body)` is the **raw 32-byte
+//! digest** of the body (an empty body for GET) appended directly — not hex, not
+//! base64. The resulting MAC is base64 (standard alphabet) encoded:
+//!
+//! ```text
+//! Authorization = access_key + ":" + base64(HMAC_SHA256(secret_bytes, canonical))
+//! ```
+//!
+//! `secret_bytes` is the base64 decoding of the credential's secret key.
 
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+type HmacSha256 = Hmac<Sha256>;
 
 /// Errors produced while signing a request.
 #[derive(Debug, Error)]
@@ -17,17 +42,98 @@ pub enum SigningError {
 #[derive(Debug, Clone)]
 pub struct Credentials {
     pub access_key: String,
+    /// The secret key, base64-encoded (standard alphabet), as stored in config.
     pub secret_key: String,
 }
 
 /// Computes the `Authorization` header value for an ASHIRT API request.
-// TODO(aterm-8tn.3): implement HMAC-SHA256 over the canonical request.
-// Deps to add then: `hmac`, `sha2`, `base64`.
+///
+/// `request_uri` is the path including any query string. `date` is the value of
+/// the request's `Date` header, which must be formatted as RFC 1123 in GMT and
+/// identical to what is sent on the wire. `body` is the raw request body (empty
+/// for GET).
 pub fn sign_request(
-    _creds: &Credentials,
-    _method: &str,
-    _path: &str,
-    _body: &[u8],
+    creds: &Credentials,
+    method: &str,
+    request_uri: &str,
+    date: &str,
+    body: &[u8],
 ) -> Result<String, SigningError> {
-    todo!("aterm-8tn.3: HMAC-SHA256 ASHIRT request signing")
+    let secret_bytes = STANDARD
+        .decode(creds.secret_key.as_bytes())
+        .map_err(|_| SigningError::InvalidSecret)?;
+
+    // Canonical request: METHOD \n REQUEST_URI \n DATE \n SHA256(body).
+    // The body digest is the raw 32 digest bytes, appended directly.
+    let body_digest = Sha256::digest(body);
+
+    let mut canonical = Vec::new();
+    canonical.extend_from_slice(method.as_bytes());
+    canonical.push(b'\n');
+    canonical.extend_from_slice(request_uri.as_bytes());
+    canonical.push(b'\n');
+    canonical.extend_from_slice(date.as_bytes());
+    canonical.push(b'\n');
+    canonical.extend_from_slice(&body_digest);
+
+    // HMAC accepts a key of any length, so this never fails.
+    let mut mac =
+        HmacSha256::new_from_slice(&secret_bytes).expect("HMAC-SHA256 accepts keys of any length");
+    mac.update(&canonical);
+    let signature = mac.finalize().into_bytes();
+
+    Ok(format!(
+        "{}:{}",
+        creds.access_key,
+        STANDARD.encode(signature)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Golden vector computed by an INDEPENDENT oracle (Python `hmac`/`hashlib`),
+    /// NOT by this Rust implementation. Asserting against this literal proves the
+    /// port reproduces an externally-derived MAC byte-for-byte and breaks any
+    /// self-referential circularity.
+    #[test]
+    fn golden_vector_get_empty_body() {
+        let creds = Credentials {
+            access_key: "test-access-key".to_string(),
+            secret_key: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=".to_string(),
+        };
+
+        let auth = sign_request(
+            &creds,
+            "GET",
+            "/api/operations",
+            "Mon, 02 Jan 2006 15:04:05 GMT",
+            b"",
+        )
+        .expect("signing must succeed for a valid secret");
+
+        assert_eq!(
+            auth,
+            "test-access-key:BPZTE5El8Zw7uXr3sFyb1r9QuWeHgPTrbqSU3u0lbYY="
+        );
+    }
+
+    #[test]
+    fn invalid_secret_is_rejected() {
+        let creds = Credentials {
+            access_key: "test-access-key".to_string(),
+            secret_key: "not valid base64!!!".to_string(),
+        };
+
+        let err = sign_request(
+            &creds,
+            "GET",
+            "/api/operations",
+            "Mon, 02 Jan 2006 15:04:05 GMT",
+            b"",
+        )
+        .expect_err("malformed base64 secret must be rejected");
+        assert!(matches!(err, SigningError::InvalidSecret));
+    }
 }


### PR DESCRIPTION
Ports ashirt-server/signer. Authorization = accessKey:base64(HMAC-SHA256(secret, METHOD\nURI\nDATE\nraw-sha256(body))). hmac 0.13 + sha2 0.11 + base64 0.22. Independent golden-vector test (externally derived, non-circular) + invalid-secret rejection. Gates (orchestrator-run): build/test(4)/clippy -Dwarnings/fmt pass. Security review: pass (canonical/base64/error-handling verified; minor follow-up: redact secret in Debug). Base: rust-rewrite.