### PR TITLE
TUI foundation: inquire prompt/menu primitives (aterm-8tn.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --all-targets --verbose
 
       - name: Test
         run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "clap",
  "directories",
  "hmac",
+ "inquire",
  "serde",
  "serde_yaml_ng",
  "sha2",
@@ -81,7 +82,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7179c44abe2ac36173d4713bfed24136e5988f005c7fe2c4fcde621d3d4d29b9"
 dependencies = [
  "rgb",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -89,6 +90,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -170,12 +177,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -194,6 +237,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -230,10 +295,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
 
 [[package]]
 name = "getrandom"
@@ -287,6 +386,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +427,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +476,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -341,6 +516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -364,10 +548,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -424,6 +642,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,10 +737,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -495,6 +771,28 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.22.1"
 clap = { version = "4.6.1", features = ["derive"] }
 directories = "6.0.0"
 hmac = "0.13.0"
+inquire = "0.9.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml_ng = "0.10.0"
 sha2 = "0.11.0"

--- a/examples/tui_demo.rs
+++ b/examples/tui_demo.rs
@@ -39,6 +39,11 @@ fn main() {
         Err(e) => println!("confirm: {e}"),
     }
 
+    match tui::input("A short note") {
+        Ok(note) => println!("note: {note}"),
+        Err(e) => println!("input: {e}"),
+    }
+
     match tui::input_with_default("Your name", "anonymous") {
         Ok(name) => println!("hello, {}", tui::bold(&name)),
         Err(e) => println!("input: {e}"),

--- a/examples/tui_demo.rs
+++ b/examples/tui_demo.rs
@@ -1,0 +1,56 @@
+//! MANUAL-ONLY interactive demo of the `aterm::tui` prompt wrappers.
+//!
+//! This is NOT part of the test suite and is never run by CI or the
+//! orchestrator — those environments are headless (no TTY), and every prompt
+//! below enables raw mode, which hangs or errors without a real terminal. CI
+//! only *compiles* this file (via `cargo build --all-targets` / clippy) to keep
+//! the wrappers honest.
+//!
+//! To try it yourself, in an interactive terminal:
+//!
+//! ```text
+//! cargo run --example tui_demo
+//! ```
+//!
+//! Use the arrow keys to move, type to filter, Enter to select, Space to toggle
+//! multiselect items, and Esc / Ctrl-C to cancel any prompt.
+
+use aterm::tui;
+
+fn main() {
+    let fruits: Vec<String> = ["Apple", "Banana", "Cherry", "Date", "Elderberry"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    match tui::select("Pick a fruit", &fruits) {
+        Ok(choice) => println!("selected: {}  {}", choice, tui::green_check()),
+        Err(e) => println!("select: {e}  {}", tui::red_cross()),
+    }
+
+    match tui::multiselect("Pick any fruits", &fruits) {
+        Ok(choices) => println!("selected: {choices:?}"),
+        Err(e) => println!("multiselect: {e}"),
+    }
+
+    match tui::confirm("Continue?", true) {
+        Ok(true) => println!("{}", tui::green("yes")),
+        Ok(false) => println!("{}", tui::red("no")),
+        Err(e) => println!("confirm: {e}"),
+    }
+
+    match tui::input_with_default("Your name", "anonymous") {
+        Ok(name) => println!("hello, {}", tui::bold(&name)),
+        Err(e) => println!("input: {e}"),
+    }
+
+    match tui::required_input("Operation slug (required)") {
+        Ok(slug) => println!("slug: {slug}"),
+        Err(e) => println!("required_input: {e}"),
+    }
+
+    match tui::password("API secret key") {
+        Ok(secret) => println!("captured {} masked chars", secret.len()),
+        Err(e) => println!("password: {e}"),
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,27 +1,254 @@
 //! Terminal UI prompt wrappers.
 //!
-//! Thin wrappers over interactive prompts so the rest of the app never depends
-//! on the prompt library directly. The concrete impls land in aterm-8tn.5 and
-//! will use `inquire` (over `crossterm`).
+//! Thin, reusable wrappers over interactive prompts so the rest of the app never
+//! depends on the prompt library directly. This is the Rust replacement for the
+//! Go `promptui`-based `dialog/` package plus the `fancy/` styling helpers.
+//!
+//! Built on [`inquire`] (over its default `crossterm` backend). The wrappers
+//! cover the primitives the app needs: a searchable single-select, a
+//! multiselect, a yes/no confirm, a free-text prompt, and a masked password
+//! prompt, plus a handful of pure styling helpers.
+//!
+//! # Headless note
+//!
+//! Anything that actually drives a terminal (`inquire`'s `.prompt()`, raw mode,
+//! etc.) requires a TTY and will fail or hang without one — so it can never run
+//! in CI or under the orchestrator. To keep this module testable, ALL decision
+//! logic (option filtering / fuzzy match, input validation, styling/formatting)
+//! is factored into standalone pure functions that are unit-tested below; the
+//! interactive wrappers are thin shells that wire those pure functions into
+//! `inquire`. A runnable demo of the interactive prompts lives in
+//! `examples/tui_demo.rs` and is **manual-only** (run it yourself in a real
+//! terminal — it is never exercised by the test suite).
 
+use inquire::validator::Validation;
+use inquire::{Confirm, InquireError, MultiSelect, Password, PasswordDisplayMode, Select, Text};
 use thiserror::Error;
 
 /// Errors produced by interactive prompts.
 #[derive(Debug, Error)]
 pub enum TuiError {
-    /// The user aborted the prompt (e.g. Ctrl-C / Esc).
+    /// The user aborted the prompt (Esc / Ctrl-C / EOF).
     #[error("prompt cancelled")]
     Cancelled,
+
+    /// The prompt could not run (e.g. no TTY) or failed mid-flight.
+    #[error("prompt failed: {0}")]
+    Prompt(String),
 }
 
-/// Prompts the user to choose one of `options`.
-// TODO(aterm-8tn.5): implement via `inquire::Select`.
-pub fn select(_message: &str, _options: &[String]) -> Result<String, TuiError> {
-    todo!("aterm-8tn.5: select prompt via inquire")
+impl From<InquireError> for TuiError {
+    fn from(err: InquireError) -> Self {
+        match err {
+            // Treat Esc and Ctrl-C uniformly as a user-initiated cancel; this
+            // mirrors the Go `dialog` package collapsing ErrInterrupt/ErrEOF
+            // into a single "kill signal".
+            InquireError::OperationCanceled | InquireError::OperationInterrupted => {
+                TuiError::Cancelled
+            }
+            other => TuiError::Prompt(other.to_string()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure logic (headless-testable). The interactive wrappers below delegate here.
+// ---------------------------------------------------------------------------
+
+/// Case-insensitive substring score used to filter select/multiselect options.
+///
+/// Returns `Some(score)` when `input` appears (ignoring case) somewhere in
+/// `label`, and `None` otherwise. `inquire` keeps any option scoring `Some` and
+/// drops those scoring `None`; a constant score preserves the original option
+/// order among matches. This intentionally reproduces the Go
+/// `SearcherContainsCI` behaviour (plain substring match) rather than the fuzzy
+/// matching `inquire` ships by default, so menus filter predictably.
+pub fn score_contains_ci(input: &str, label: &str) -> Option<i64> {
+    if input.is_empty() {
+        return Some(0);
+    }
+    if label.to_lowercase().contains(&input.to_lowercase()) {
+        Some(0)
+    } else {
+        None
+    }
+}
+
+/// Whether `input` is acceptable as a "required" free-text answer.
+///
+/// Mirrors the validation we attach to required prompts: input is rejected if it
+/// is empty or only whitespace.
+pub fn is_non_empty(input: &str) -> bool {
+    !input.trim().is_empty()
+}
+
+// ---------------------------------------------------------------------------
+// Styling helpers (pure ANSI string decoration).
+// ---------------------------------------------------------------------------
+
+const ANSI_RESET: &str = "\x1b[0m";
+
+fn wrap(code: &str, s: &str) -> String {
+    format!("\x1b[{code}m{s}{ANSI_RESET}")
+}
+
+/// Wraps `s` in ANSI bold.
+pub fn bold(s: &str) -> String {
+    wrap("1", s)
+}
+
+/// Wraps `s` in ANSI green.
+pub fn green(s: &str) -> String {
+    wrap("32", s)
+}
+
+/// Wraps `s` in ANSI red.
+pub fn red(s: &str) -> String {
+    wrap("31", s)
+}
+
+/// A green check mark, used to denote success / a "yes" choice.
+pub fn green_check() -> String {
+    green("\u{2713}") // ✓
+}
+
+/// A red cross, used to denote failure / a "no" choice.
+pub fn red_cross() -> String {
+    red("\u{2717}") // ✗
+}
+
+// ---------------------------------------------------------------------------
+// Interactive wrappers. MANUAL/TTY-ONLY: never call these from tests or any
+// default (headless) code path — `.prompt()` enables raw mode and will hang or
+// error without a real terminal.
+// ---------------------------------------------------------------------------
+
+/// Prompts the user to choose one of `options` via a searchable select list.
+///
+/// Filtering is case-insensitive substring matching (see [`score_contains_ci`]).
+pub fn select(message: &str, options: &[String]) -> Result<String, TuiError> {
+    Select::new(message, options.to_vec())
+        .with_scorer(&|input, _opt, value, _idx| score_contains_ci(input, value))
+        .prompt()
+        .map_err(TuiError::from)
+}
+
+/// Prompts the user to choose zero or more of `options` via a searchable
+/// multiselect list. Returns the selected labels in display order.
+pub fn multiselect(message: &str, options: &[String]) -> Result<Vec<String>, TuiError> {
+    MultiSelect::new(message, options.to_vec())
+        .with_scorer(&|input, _opt, value, _idx| score_contains_ci(input, value))
+        .prompt()
+        .map_err(TuiError::from)
+}
+
+/// Asks a yes/no question, returning `true` for yes. `default` is the answer
+/// applied when the user submits an empty response.
+pub fn confirm(message: &str, default: bool) -> Result<bool, TuiError> {
+    Confirm::new(message)
+        .with_default(default)
+        .prompt()
+        .map_err(TuiError::from)
 }
 
 /// Prompts the user for a line of free-text input.
-// TODO(aterm-8tn.5): implement via `inquire::Text`.
-pub fn input(_message: &str) -> Result<String, TuiError> {
-    todo!("aterm-8tn.5: text input via inquire")
+pub fn input(message: &str) -> Result<String, TuiError> {
+    Text::new(message).prompt().map_err(TuiError::from)
+}
+
+/// Prompts for free-text input, pre-filling `default` (used when the user
+/// submits an empty response).
+pub fn input_with_default(message: &str, default: &str) -> Result<String, TuiError> {
+    Text::new(message)
+        .with_default(default)
+        .prompt()
+        .map_err(TuiError::from)
+}
+
+/// Prompts for free-text input that must be non-empty (see [`is_non_empty`]).
+pub fn required_input(message: &str) -> Result<String, TuiError> {
+    Text::new(message)
+        .with_validator(|s: &str| {
+            if is_non_empty(s) {
+                Ok(Validation::Valid)
+            } else {
+                Ok(Validation::Invalid("a value is required".into()))
+            }
+        })
+        .prompt()
+        .map_err(TuiError::from)
+}
+
+/// Prompts for a secret value. Input is masked and no confirmation re-entry is
+/// required (this is an entry prompt, not a "set a new password" flow).
+pub fn password(message: &str) -> Result<String, TuiError> {
+    Password::new(message)
+        .with_display_mode(PasswordDisplayMode::Masked)
+        .without_confirmation()
+        .prompt()
+        .map_err(TuiError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_matches_case_insensitively() {
+        assert!(score_contains_ci("ash", "ASHIRT").is_some());
+        assert!(score_contains_ci("HIRT", "ashirt").is_some());
+        assert!(score_contains_ci("shi", "ashirt").is_some());
+    }
+
+    #[test]
+    fn score_rejects_non_substring() {
+        assert!(score_contains_ci("xyz", "ashirt").is_none());
+        assert!(score_contains_ci("ashirtx", "ashirt").is_none());
+    }
+
+    #[test]
+    fn empty_input_matches_everything() {
+        assert!(score_contains_ci("", "anything").is_some());
+        assert!(score_contains_ci("", "").is_some());
+    }
+
+    #[test]
+    fn score_filter_keeps_only_matching_options() {
+        let options = ["San Antonio", "San Diego", "Dallas", "San Jose", "Austin"];
+        let kept: Vec<&str> = options
+            .iter()
+            .copied()
+            .filter(|label| score_contains_ci("san", label).is_some())
+            .collect();
+        assert_eq!(kept, ["San Antonio", "San Diego", "San Jose"]);
+    }
+
+    #[test]
+    fn non_empty_validation() {
+        assert!(is_non_empty("hello"));
+        assert!(is_non_empty("  x  "));
+        assert!(!is_non_empty(""));
+        assert!(!is_non_empty("   "));
+        assert!(!is_non_empty("\t\n"));
+    }
+
+    #[test]
+    fn styling_wraps_and_resets() {
+        assert_eq!(bold("hi"), "\x1b[1mhi\x1b[0m");
+        assert_eq!(green("ok"), "\x1b[32mok\x1b[0m");
+        assert_eq!(red("no"), "\x1b[31mno\x1b[0m");
+    }
+
+    #[test]
+    fn glyph_helpers_are_colored() {
+        let check = green_check();
+        assert!(check.contains('\u{2713}'));
+        assert!(check.starts_with("\x1b[32m"));
+        assert!(check.ends_with(ANSI_RESET));
+
+        let cross = red_cross();
+        assert!(cross.contains('\u{2717}'));
+        assert!(cross.starts_with("\x1b[31m"));
+        assert!(cross.ends_with(ANSI_RESET));
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -28,9 +28,13 @@ use thiserror::Error;
 /// Errors produced by interactive prompts.
 #[derive(Debug, Error)]
 pub enum TuiError {
-    /// The user aborted the prompt (Esc / Ctrl-C / EOF).
+    /// The user aborted the prompt by pressing Esc.
     #[error("prompt cancelled")]
     Cancelled,
+
+    /// The user interrupted the prompt by pressing Ctrl-C.
+    #[error("prompt interrupted")]
+    Interrupted,
 
     /// The prompt could not run (e.g. no TTY) or failed mid-flight.
     #[error("prompt failed: {0}")]
@@ -40,12 +44,8 @@ pub enum TuiError {
 impl From<InquireError> for TuiError {
     fn from(err: InquireError) -> Self {
         match err {
-            // Treat Esc and Ctrl-C uniformly as a user-initiated cancel; this
-            // mirrors the Go `dialog` package collapsing ErrInterrupt/ErrEOF
-            // into a single "kill signal".
-            InquireError::OperationCanceled | InquireError::OperationInterrupted => {
-                TuiError::Cancelled
-            }
+            InquireError::OperationCanceled => TuiError::Cancelled,
+            InquireError::OperationInterrupted => TuiError::Interrupted,
             other => TuiError::Prompt(other.to_string()),
         }
     }
@@ -221,6 +221,18 @@ mod tests {
             .filter(|label| score_contains_ci("san", label).is_some())
             .collect();
         assert_eq!(kept, ["San Antonio", "San Diego", "San Jose"]);
+    }
+
+    #[test]
+    fn canceled_maps_to_cancelled() {
+        let mapped = TuiError::from(InquireError::OperationCanceled);
+        assert!(matches!(mapped, TuiError::Cancelled));
+    }
+
+    #[test]
+    fn interrupted_maps_to_interrupted() {
+        let mapped = TuiError::from(InquireError::OperationInterrupted);
+        assert!(matches!(mapped, TuiError::Interrupted));
     }
 
     #[test]


### PR DESCRIPTION
Replaces promptui/dialog/fancy. inquire-based searchable select/multiselect/confirm/text/password wrappers + pure logic unit-tested (headless-safe: no raw mode in src/tests; interactive demo in examples/tui_demo.rs only). Re-review fixes: TuiError Cancelled/Interrupted tests, demo input(), CI build --all-targets. Rebased onto current base; Cargo.lock re-locked. Gates: build/test(19 crate-wide)/clippy -Dwarnings/fmt pass. Review: pass. Base: rust-rewrite.