### PR TITLE
Application entry point and orchestration (aterm-8tn.14)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,31 +1,242 @@
 //! Application orchestration — the entrypoint wiring called by `main`.
 //!
+//! This replaces the Go `cmd/aterm/climain.go`: parse CLI -> first-run wizard if
+//! the config is missing or a reset was requested -> resolve config -> build the
+//! ASHIRT client -> validate -> update check -> either the main menu or an
+//! immediate recording, with the post-recording upload menu wired in afterwards.
+//!
 //! This is the `anyhow` BOUNDARY: typed module errors (`thiserror`) bubble up
 //! here and get human-facing context via [`anyhow::Context`]. Nothing below this
 //! layer should use `anyhow`.
+//!
+//! # Headless gate
+//!
+//! [`run`] is interactive (menus, recorder, network) and must never run in tests
+//! or without a TTY. The two decisions that drive control flow — which startup
+//! view to show ([`startup_view`]) and whether to launch the first-run wizard
+//! ([`should_run_first_run`]) — are factored into pure functions and unit-tested
+//! below; the interactive wiring itself is never exercised by the test suite.
 
 use anyhow::{Context, Result};
 
+use crate::ashirt::http::{Client, HttpError};
+use crate::ashirt::signing::Credentials;
 use crate::cli::Cli;
-use crate::config::Config;
+use crate::config::{self, Config};
+use crate::config_setup;
+use crate::menu;
+use crate::update::{self, SemVer, UpgradeResult};
+
+/// GitHub repository queried for the update check. The Go build injected these
+/// via ldflags; here they are the canonical upstream coordinates.
+const CODE_OWNER: &str = "ashirt-ops";
+const CODE_REPO: &str = "aterm";
+
+/// The view aterm starts in once configuration is resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartupView {
+    /// The interactive main menu (`menu::run`).
+    Menu,
+    /// Record a session immediately (the default Go action).
+    Record,
+}
+
+/// Decides the startup view from the resolved flags and validation outcome.
+///
+/// Mirrors the Go climain: `--menu` (`ShowMenu`) **or** a failed validation force
+/// the main menu so the user can react; otherwise recording starts immediately.
+fn startup_view(menu_flag: bool, validation_ok: bool) -> StartupView {
+    if menu_flag || !validation_ok {
+        StartupView::Menu
+    } else {
+        StartupView::Record
+    }
+}
+
+/// Decides whether the first-run setup wizard should run.
+///
+/// Mirrors the Go climain trigger: a missing config file, a soft `--reset`, or a
+/// hard `--reset-hard` each force first-run setup. `--reset-hard` additionally
+/// ignores any existing config (handled by the seed computation in [`run_first_run`]).
+fn should_run_first_run(config_exists: bool, reset: bool, reset_hard: bool) -> bool {
+    reset || reset_hard || !config_exists
+}
 
 /// Runs aterm end to end.
 pub fn run(cli: Cli) -> Result<()> {
-    if cli.reset || cli.reset_hard {
-        // TODO(aterm-8tn.4): clear saved config (and recordings if --reset-hard).
-        return Ok(());
+    // First-run setup if the config is missing or a reset was requested. This
+    // writes a fresh config file before we resolve the effective configuration.
+    if should_run_first_run(config_file_exists(), cli.reset, cli.reset_hard) {
+        run_first_run(&cli).context("running first-run configuration")?;
     }
 
-    // Example of the typed-error -> anyhow boundary: `Config::load` returns a
-    // `ConfigError` (thiserror); `.context(..)` lifts it into `anyhow::Error`.
+    // Resolve configuration: built-in defaults < config file < CLI flags. After a
+    // first run this re-reads the freshly written file, so CLI flags still win.
     let config = Config::load(&cli).context("loading aterm configuration")?;
 
+    // Build the ASHIRT API client from the resolved config (base URL +
+    // credentials). Mirrors the Go `network.SetBaseURL` / `SetAccessKey`.
+    let client = build_client(&config).context("building ASHIRT API client")?;
+
+    // Validate the resolved config. On failure, surface every problem and fall
+    // back to the main menu instead of recording.
+    let validation_ok = match config_setup::validate(&config) {
+        Ok(()) => true,
+        Err(errs) => {
+            eprintln!("{errs}");
+            false
+        }
+    };
+
+    // Update check. Kept as a single call site so aterm-8tn.20 can later gate it
+    // behind a config flag; for now it always checks.
+    notify_update();
+
+    // `--print-config` prints the resolved config and exits, after validation and
+    // the update notice (matching the Go ordering).
     if cli.print_config {
         println!("{config}");
         return Ok(());
     }
 
-    // TODO(aterm-8tn.7+): build a recorder, run the session, stream asciicast,
-    // then upload the recording as ASHIRT evidence.
-    todo!("app::run: wire recorder -> asciicast -> ashirt::upload")
+    match startup_view(cli.menu, validation_ok) {
+        StartupView::Menu => menu::run(&config, &client).context("main menu")?,
+        StartupView::Record => menu::record_once(&config, &client).context("recording session")?,
+    }
+
+    Ok(())
+}
+
+/// Runs the first-run setup wizard and writes the resulting configuration.
+///
+/// The wizard is seeded per the reset flags (mirroring the Go `FirstRun`):
+/// `--reset-hard` ignores any saved config and starts from defaults; `--reset`
+/// (and a plain first run) seed from the existing config when one is present.
+/// Empty fields are then seeded from the ASHIRT desktop config (best-effort).
+fn run_first_run(cli: &Cli) -> Result<()> {
+    let existing = if cli.reset_hard {
+        None
+    } else {
+        config::config_path()
+            .ok()
+            .filter(|path| path.exists())
+            .and_then(|path| Config::read_file(&path).ok())
+    };
+
+    let mut seed = config_setup::wizard_seed(existing.as_ref(), cli.reset_hard);
+
+    // Seeding from another ASHIRT application is best-effort: a missing or
+    // unreadable desktop config simply leaves the seed unchanged.
+    let _ = config_setup::import_ashirt(&mut seed);
+
+    let config = config_setup::run_first_run_wizard(seed).context("first-run setup wizard")?;
+    config.write().context("writing configuration")?;
+    Ok(())
+}
+
+/// Builds the ASHIRT API client from the resolved configuration.
+fn build_client(config: &Config) -> Result<Client, HttpError> {
+    let creds = Credentials {
+        access_key: config.access_key.clone(),
+        secret_key: config.secret_key.clone(),
+    };
+    Client::new(&config.api_url, creds)
+}
+
+/// Returns whether the aterm config file currently exists. A failure to even
+/// determine the path is treated as "missing" so first-run setup still triggers.
+fn config_file_exists() -> bool {
+    config::config_path()
+        .map(|path| path.exists())
+        .unwrap_or(false)
+}
+
+/// Checks GitHub for a newer release and notifies the user.
+///
+/// Single call site for the update check (see [`run`]). Development builds
+/// (version `0.0.0`) skip the network check, mirroring the Go `NotifyUpdate`
+/// guard for unversioned/development binaries.
+fn notify_update() {
+    let current = update::parse_version(env!("CARGO_PKG_VERSION"));
+    if current == SemVer::default() {
+        println!("This appears to be a development release; skipping update check.");
+        return;
+    }
+
+    match update::check_version(CODE_OWNER, CODE_REPO, &current) {
+        Ok(result) if result.has_upgrade() => report_upgrades(&result),
+        Ok(_) => {}
+        Err(err) => eprintln!("Unable to check for updates: {err}"),
+    }
+}
+
+/// Prints the available upgrades (newest of each kind) to stdout.
+fn report_upgrades(result: &UpgradeResult) {
+    println!("There is an update available.");
+    for (kind, upgrade) in [
+        ("major", &result.major),
+        ("minor", &result.minor),
+        ("patch", &result.patch),
+    ] {
+        if let Some(upgrade) = upgrade {
+            println!("  {kind} upgrade: {} ({})", upgrade.version, upgrade.tag);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- startup-view decision ------------------------------------------------
+
+    #[test]
+    fn startup_view_records_when_valid_and_menu_not_requested() {
+        assert_eq!(startup_view(false, true), StartupView::Record);
+    }
+
+    #[test]
+    fn startup_view_shows_menu_when_menu_flag_set() {
+        // The menu flag forces the menu even when the config is valid.
+        assert_eq!(startup_view(true, true), StartupView::Menu);
+    }
+
+    #[test]
+    fn startup_view_shows_menu_when_validation_failed() {
+        // A failed validation forces the menu regardless of the menu flag.
+        assert_eq!(startup_view(false, false), StartupView::Menu);
+        assert_eq!(startup_view(true, false), StartupView::Menu);
+    }
+
+    // --- first-run trigger decision -------------------------------------------
+
+    #[test]
+    fn first_run_triggers_when_config_missing() {
+        assert!(should_run_first_run(false, false, false));
+    }
+
+    #[test]
+    fn first_run_skipped_when_config_present_and_no_reset() {
+        assert!(!should_run_first_run(true, false, false));
+    }
+
+    #[test]
+    fn first_run_triggers_on_soft_reset_even_with_config_present() {
+        assert!(should_run_first_run(true, true, false));
+    }
+
+    #[test]
+    fn first_run_triggers_on_hard_reset_even_with_config_present() {
+        assert!(should_run_first_run(true, false, true));
+    }
+
+    #[test]
+    fn first_run_triggers_when_missing_regardless_of_reset() {
+        // Every combination with a missing config triggers first-run.
+        for reset in [false, true] {
+            for reset_hard in [false, true] {
+                assert!(should_run_first_run(false, reset, reset_hard));
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,15 @@
 //! aterm binary entrypoint. Thin on purpose: parse the CLI, hand off to
-//! [`aterm::app::run`], and let `anyhow` render any error at the boundary.
+//! [`aterm::app::run`], and render any error at the `anyhow` boundary as a clean
+//! message before exiting non-zero.
 
-use anyhow::Result;
 use clap::Parser;
 
-fn main() -> Result<()> {
+fn main() {
     let cli = aterm::cli::Cli::parse();
-    aterm::app::run(cli)
+    if let Err(err) = aterm::app::run(cli) {
+        // `{:#}` renders the full anyhow context chain on one line, without the
+        // Debug backtrace noise the default `fn main() -> Result` would print.
+        eprintln!("Error: {err:#}");
+        std::process::exit(1);
+    }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -38,10 +38,10 @@ use thiserror::Error;
 
 use crate::ashirt::http::{Client, HttpError};
 use crate::ashirt::ops_tags::{list_operations, Operation};
-use crate::ashirt::signing::Credentials;
 use crate::config::Config;
 use crate::recorder::{record_session, RecorderError};
 use crate::tui::{self, TuiError};
+use crate::upload_menu;
 
 /// Errors produced by the menu / recording flow.
 #[derive(Debug, Error)]
@@ -58,6 +58,10 @@ pub enum MenuError {
     /// The recording session itself failed.
     #[error("recording failed")]
     Recorder(#[from] RecorderError),
+
+    /// The post-recording (upload) menu failed.
+    #[error("post-recording menu failed")]
+    UploadMenu(#[from] upload_menu::MenuError),
 
     /// The recording output directory could not be created.
     #[error("failed to create recording directory {path}")]
@@ -238,18 +242,17 @@ pub fn output_path(output_dir: &str, slug: &str, file_name: &str) -> PathBuf {
 // ---------------------------------------------------------------------------
 
 /// Runs the main menu loop. This is the entry point the application entrypoint
-/// (aterm-8tn.14) calls after configuration is resolved.
+/// (aterm-8tn.14) calls after configuration is resolved; `client` is built by the
+/// entrypoint from the resolved config and shared with the recording flow.
 ///
 /// Operations are fetched once up front (a failure is reported but non-fatal, so
 /// the menu still opens and the user can retry via "Refresh operations"). Each
 /// loop iteration prompts the main menu and dispatches the chosen action;
-/// recording returns here when it finishes, keeping menu and recording as
-/// separate phases. The loop exits on "Quit" or when the user cancels the menu
-/// prompt (Esc / Ctrl-C).
-pub fn run(config: &Config) -> Result<(), MenuError> {
-    let client = build_client(config)?;
-
-    let mut operations = match list_operations(&client) {
+/// recording returns here when it (and its post-recording menu) finishes, keeping
+/// menu and recording as separate phases. The loop exits on "Quit" or when the
+/// user cancels the menu prompt (Esc / Ctrl-C).
+pub fn run(config: &Config, client: &Client) -> Result<(), MenuError> {
+    let mut operations = match list_operations(client) {
         Ok(ops) => ops,
         Err(err) => {
             eprintln!("Unable to retrieve operations list: {err}");
@@ -267,8 +270,8 @@ pub fn run(config: &Config) -> Result<(), MenuError> {
         };
 
         match dispatch_main_menu(&selection) {
-            Some(MenuAction::StartRecording) => start_recording(config, &operations)?,
-            Some(MenuAction::RefreshOperations) => match list_operations(&client) {
+            Some(MenuAction::StartRecording) => start_recording(config, client, &operations)?,
+            Some(MenuAction::RefreshOperations) => match list_operations(client) {
                 Ok(ops) => {
                     println!("Updated operations ({} total)", ops.len());
                     operations = ops;
@@ -283,10 +286,31 @@ pub fn run(config: &Config) -> Result<(), MenuError> {
     Ok(())
 }
 
+/// Records a single session immediately, then presents the post-recording menu.
+///
+/// This is the default startup view the entrypoint (aterm-8tn.14) uses when not
+/// forced into the main menu — mirroring the Go `MenuViewRecording` start view.
+/// Operations are fetched up front; a fetch failure is reported but non-fatal, so
+/// the user still reaches the (possibly empty) operation prompt.
+pub fn record_once(config: &Config, client: &Client) -> Result<(), MenuError> {
+    let operations = match list_operations(client) {
+        Ok(ops) => ops,
+        Err(err) => {
+            eprintln!("Unable to retrieve operations list: {err}");
+            Vec::new()
+        }
+    };
+    start_recording(config, client, &operations)
+}
+
 /// Prompts for an operation and records a session against it, writing the cast
-/// to `<output_dir>/<slug>/<file_name>` and returning to the caller (the menu
-/// loop) when the recording finishes.
-fn start_recording(config: &Config, operations: &[Operation]) -> Result<(), MenuError> {
+/// to `<output_dir>/<slug>/<file_name>`, then presents the post-recording upload
+/// menu before returning to the caller (the menu loop or the entrypoint).
+fn start_recording(
+    config: &Config,
+    client: &Client,
+    operations: &[Operation],
+) -> Result<(), MenuError> {
     if operations.is_empty() {
         println!("Unable to record: no operations available (try \"Refresh operations\").");
         return Ok(());
@@ -339,16 +363,15 @@ fn start_recording(config: &Config, operations: &[Operation]) -> Result<(), Menu
         path.display()
     );
 
-    Ok(())
-}
+    // Present the post-recording menu (upload / rename / discard). Backing out of
+    // it (Esc / Ctrl-C) returns to the caller rather than surfacing as an error.
+    match upload_menu::post_recording_menu(client, &slug, &path) {
+        Ok(()) => {}
+        Err(upload_menu::MenuError::Tui(TuiError::Cancelled | TuiError::Interrupted)) => {}
+        Err(err) => return Err(err.into()),
+    }
 
-/// Builds the ASHIRT API client from the resolved configuration.
-fn build_client(config: &Config) -> Result<Client, HttpError> {
-    let creds = Credentials {
-        access_key: config.access_key.clone(),
-        secret_key: config.secret_key.clone(),
-    };
-    Client::new(&config.api_url, creds)
+    Ok(())
 }
 
 /// Picks the shell to record: the configured shell, falling back to `$SHELL`,


### PR DESCRIPTION
Wires the full app (replaces climain + app.rs todo!): CLI -> config load -> first-run (missing/reset/reset-hard) -> ASHIRT client -> validate (menu on fail) -> update check (single gateable seam for .20) -> -pc print/exit -> startup view (menu if -m or invalid, else record) -> upload_menu after record. main.rs anyhow boundary. Pure startup_view + first-run decisions unit-tested. Gates pass; review pass. Base: rust-rewrite.