### PR TITLE
Cross-platform CI + release binaries (aterm-8tn.15)

### DIFF
--- a/.github/workflows/WORKFLOWS.md
+++ b/.github/workflows/WORKFLOWS.md
@@ -1,0 +1,27 @@
+# CI workflows
+
+During the Rust rewrite the repository carries **two** GitHub Actions
+workflows. Both are active and are expected to coexist until the rewrite
+becomes the shipping artifact on `main`.
+
+| File       | Name     | Language | Triggers                          | Purpose |
+|------------|----------|----------|-----------------------------------|---------|
+| `ci.yaml`  | `ci`     | Go       | push/PR to `main`, tags `v*`      | Legacy: builds/tests/lints the original Go sources, signs+notarizes the macOS binary, and publishes GitHub Release zips for the Go binaries. **Do not delete yet** — it is what currently ships from `main`. |
+| `ci.yml`   | `Rust CI`| Rust     | every push, every PR, tags `v*`   | Rewrite: build/test/clippy (`-D warnings`)/fmt across Linux/macOS/Windows, a `--features playback` build to keep the optional `avt` path compiling, and a tag-triggered job that builds optimized release binaries for each OS and uploads them as workflow artifacts. |
+
+## Why both
+
+The rewrite lives on the `rust-rewrite` branch. The Go workflow targets `main`
+only, so it does not run on rewrite branches/PRs; the Rust workflow runs on all
+pushes and PRs. They therefore do not collide on day-to-day rewrite work. On a
+`v*` tag both can fire — the Go workflow produces the Go release, the Rust
+workflow uploads the Rust binaries as artifacts.
+
+## Migration plan
+
+When the Rust rewrite replaces the Go binary on `main`:
+
+1. Move the release/publish responsibilities (GitHub Release creation, asset
+   upload, macOS signing/notarization) from `ci.yaml` into `ci.yml`.
+2. Delete `ci.yaml` and the Go sources.
+3. Rename `ci.yml` → `ci.yaml` (or keep, per preference).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,10 @@
+# Rust CI for the aterm Rust rewrite.
+#
+# This is the workflow for the Rust crate (build/test/clippy/fmt across
+# Linux/macOS/Windows, plus tag-triggered release binaries). The legacy Go
+# workflow lives in `ci.yaml` and still builds the original Go sources on
+# pushes/PRs to `main`. Both run today; see README / WORKFLOWS.md for the
+# migration plan. Do NOT delete the Go workflow until the rewrite lands on main.
 name: Rust CI
 
 on:
@@ -29,6 +36,11 @@ jobs:
       - name: Build
         run: cargo build --all-targets --verbose
 
+      # Exercise the optional avt/playback path so it stays compiling on every
+      # OS; the default feature set above does not pull in `avt`.
+      - name: Build (playback feature)
+        run: cargo build --features playback --verbose
+
       - name: Test
         run: cargo test --verbose
 
@@ -37,3 +49,51 @@ jobs:
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
+
+  # Optimized release binaries for each OS, uploaded as workflow artifacts.
+  # Runs only on version tags (v*). Publishing these to a GitHub Release is
+  # handled separately once the rewrite is the shipping artifact.
+  release:
+    name: release binary (${{ matrix.os }})
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target_label: linux
+            bin: aterm
+          - os: macos-latest
+            target_label: macos
+            bin: aterm
+          - os: windows-latest
+            target_label: windows
+            bin: aterm.exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --verbose
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/release/${{ matrix.bin }}" dist/
+          cp LICENSE dist/ 2>/dev/null || true
+          cp README.md dist/ 2>/dev/null || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aterm-${{ github.ref_name }}-${{ matrix.target_label }}
+          path: dist
+          if-no-files-found: error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "aterm"
 version = "0.0.0"
 edition = "2021"
+# MSRV: code uses Option::is_none_or (stabilized in 1.82).
+rust-version = "1.82"
 description = "ASHIRT terminal recorder (Rust rewrite)"
 license = "MIT"
 repository = "https://github.com/ashirt-ops/aterm"


### PR DESCRIPTION
Rust CI: 3-OS matrix (build incl --features playback / test / clippy -Dwarnings / fmt) + tag-triggered (v*) release-binary job for linux/macos/windows; rust-version=1.82; coexists with the legacy Go ci.yaml. Gates pass locally; review pass (a 'signal-hook nonexistent' flag was a verified stale-knowledge false positive). Deferred minor: extend clippy/test to --features playback. Base: rust-rewrite.