### PR TITLE
Config option to disable auto-update check (aterm-8tn.20, gh-104)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -41,6 +41,28 @@ enum StartupView {
     Record,
 }
 
+/// Whether the startup update check should run or be skipped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UpdateCheck {
+    /// Perform the network update check.
+    Check,
+    /// Skip the check entirely (no network call).
+    Skip,
+}
+
+/// Decides whether to run the startup update check from the resolved config.
+///
+/// Gates the single [`notify_update`] seam on the `autoUpdateCheck` option
+/// (aterm-8tn.20 / gh-104): enabled => check; disabled => skip, making no
+/// network call. Kept pure so the gate decision is unit-tested directly.
+fn update_check(auto_update_check: bool) -> UpdateCheck {
+    if auto_update_check {
+        UpdateCheck::Check
+    } else {
+        UpdateCheck::Skip
+    }
+}
+
 /// Decides the startup view from the resolved flags and validation outcome.
 ///
 /// Mirrors the Go climain: `--menu` (`ShowMenu`) **or** a failed validation force
@@ -72,7 +94,8 @@ pub fn run(cli: Cli) -> Result<()> {
 
     // Resolve configuration: built-in defaults < config file < CLI flags. After a
     // first run this re-reads the freshly written file, so CLI flags still win.
-    let config = Config::load(&cli).context("loading aterm configuration")?;
+    // Mutable because the in-app settings menu can edit and persist it.
+    let mut config = Config::load(&cli).context("loading aterm configuration")?;
 
     // Build the ASHIRT API client from the resolved config (base URL +
     // credentials). Mirrors the Go `network.SetBaseURL` / `SetAccessKey`.
@@ -88,9 +111,13 @@ pub fn run(cli: Cli) -> Result<()> {
         }
     };
 
-    // Update check. Kept as a single call site so aterm-8tn.20 can later gate it
-    // behind a config flag; for now it always checks.
-    notify_update();
+    // Update check, gated on the `autoUpdateCheck` option (gh-104). A single call
+    // site / single decision point: when disabled we skip it entirely (no
+    // network). Development builds skip inside `notify_update` regardless.
+    match update_check(config.auto_update_check) {
+        UpdateCheck::Check => notify_update(),
+        UpdateCheck::Skip => {}
+    }
 
     // `--print-config` prints the resolved config and exits, after validation and
     // the update notice (matching the Go ordering).
@@ -100,7 +127,7 @@ pub fn run(cli: Cli) -> Result<()> {
     }
 
     match startup_view(cli.menu, validation_ok) {
-        StartupView::Menu => menu::run(&config, &client).context("main menu")?,
+        StartupView::Menu => menu::run(&mut config, &client).context("main menu")?,
         StartupView::Record => menu::record_once(&config, &client).context("recording session")?,
     }
 
@@ -187,6 +214,28 @@ fn report_upgrades(result: &UpgradeResult) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- update-check gate decision -------------------------------------------
+
+    #[test]
+    fn update_check_runs_when_enabled() {
+        assert_eq!(update_check(true), UpdateCheck::Check);
+    }
+
+    #[test]
+    fn update_check_skips_when_disabled() {
+        assert_eq!(update_check(false), UpdateCheck::Skip);
+    }
+
+    /// The gate reads the resolved config: a default config checks; disabling the
+    /// option skips.
+    #[test]
+    fn update_check_follows_config_flag() {
+        let mut cfg = Config::with_defaults();
+        assert_eq!(update_check(cfg.auto_update_check), UpdateCheck::Check);
+        cfg.auto_update_check = false;
+        assert_eq!(update_check(cfg.auto_update_check), UpdateCheck::Skip);
+    }
 
     // --- startup-view decision ------------------------------------------------
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,17 @@ pub struct Config {
     /// Shell to launch when recording.
     #[serde(rename = "recordingShell")]
     pub recording_shell: String,
+    /// Whether to check GitHub for a newer release on startup.
+    ///
+    /// Positive sense: `true` means the startup update check runs. It DEFAULTS
+    /// to enabled — but note the serde gotcha: a plain `bool` absent from the
+    /// YAML deserializes to `false`. The enabled default is therefore set in
+    /// [`Config::with_defaults`] and preserved through the partial
+    /// [`ConfigFile`] overlay, so a field absent from the file keeps `true`. The
+    /// in-app settings menu lets the user toggle it off (see
+    /// [`crate::menu::settings_menu`]); [`crate::app`] gates the check on it.
+    #[serde(rename = "autoUpdateCheck")]
+    pub auto_update_check: bool,
 }
 
 /// A partial view of the config file: every field is optional so that a field
@@ -139,6 +150,8 @@ struct ConfigFile {
     operation_slug: Option<String>,
     #[serde(rename = "recordingShell")]
     recording_shell: Option<String>,
+    #[serde(rename = "autoUpdateCheck")]
+    auto_update_check: Option<bool>,
 }
 
 impl Config {
@@ -150,6 +163,10 @@ impl Config {
         Config {
             config_version: 1,
             recording_shell: std::env::var("SHELL").unwrap_or_default(),
+            // Default ENABLED. The derived `Default` gives `false` for a bool, so
+            // the enabled default lives here and is preserved by the file overlay
+            // (absent in file => stays `true`).
+            auto_update_check: true,
             ..Config::default()
         }
     }
@@ -262,6 +279,9 @@ impl Config {
         if let Some(v) = file.recording_shell {
             self.recording_shell = v;
         }
+        if let Some(v) = file.auto_update_check {
+            self.auto_update_check = v;
+        }
     }
 }
 
@@ -277,7 +297,16 @@ impl fmt::Display for Config {
         writeln!(f, "\tSecret Key:      {}", self.secret_key)?;
         writeln!(f, "\tOutput Prefix:   {}", self.output_file_name)?;
         writeln!(f, "\tOperation Slug:  {}", self.operation_slug)?;
-        write!(f, "\tRecording Shell: {}", self.recording_shell)
+        writeln!(f, "\tRecording Shell: {}", self.recording_shell)?;
+        write!(
+            f,
+            "\tUpdate Check:    {}",
+            if self.auto_update_check {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        )
     }
 }
 
@@ -443,6 +472,7 @@ mod tests {
             output_file_name: String::new(),
             operation_slug: "op-slug".to_string(),
             recording_shell: "/bin/zsh".to_string(),
+            auto_update_check: true,
         };
 
         let path = temp_path("round-trip");
@@ -466,6 +496,55 @@ mod tests {
         // "output").
         assert!(!yaml.contains("outputFileName"));
         assert!(!yaml.contains("output_file_name"));
+    }
+
+    /// The built-in default for the update check is ENABLED.
+    #[test]
+    fn auto_update_check_defaults_enabled() {
+        assert!(Config::with_defaults().auto_update_check);
+    }
+
+    /// REQUIRED (serde gotcha): a config file that omits `autoUpdateCheck` must
+    /// keep the enabled default rather than deserializing the bool to `false`.
+    /// This exercises the real load path (defaults + partial file overlay).
+    #[test]
+    fn absent_auto_update_field_stays_enabled() {
+        let path = temp_path("auto-update-absent");
+        // A non-empty file that does NOT mention autoUpdateCheck at all.
+        fs::write(&path, "apiURL: https://ashirt.example\n").expect("write temp config");
+
+        let cfg = Config::read_file(&path).expect("read config");
+        assert!(
+            cfg.auto_update_check,
+            "absent autoUpdateCheck must stay enabled"
+        );
+        // And via the full load path (defaults < file < cli) too.
+        let cfg = Config::load_from(&path, &empty_cli()).expect("load");
+        assert!(cfg.auto_update_check, "absent => enabled through load_from");
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// The field can be turned OFF from the config file, overriding the default.
+    #[test]
+    fn auto_update_check_disabled_via_file() {
+        let path = temp_path("auto-update-off");
+        fs::write(&path, "autoUpdateCheck: false\n").expect("write temp config");
+
+        let cfg = Config::read_file(&path).expect("read config");
+        assert!(
+            !cfg.auto_update_check,
+            "autoUpdateCheck: false must disable the check"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    /// The field is persisted to the config file under its camelCase key.
+    #[test]
+    fn auto_update_check_is_persisted() {
+        let yaml = Config::with_defaults().to_yaml().expect("serialize");
+        assert!(yaml.contains("autoUpdateCheck"), "got {yaml}");
     }
 
     #[test]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -91,6 +91,8 @@ pub enum MenuAction {
     StartRecording,
     /// Re-fetch the operations list from the server.
     RefreshOperations,
+    /// Open the settings menu to edit and persist configuration.
+    Settings,
     /// Leave the application.
     Quit,
 }
@@ -118,6 +120,10 @@ pub const MAIN_MENU: &[MenuItem] = &[
         action: MenuAction::RefreshOperations,
     },
     MenuItem {
+        label: "Settings",
+        action: MenuAction::Settings,
+    },
+    MenuItem {
         label: "Quit",
         action: MenuAction::Quit,
     },
@@ -140,6 +146,48 @@ pub fn dispatch_main_menu(label: &str) -> Option<MenuAction> {
         .iter()
         .find(|item| item.label == label)
         .map(|item| item.action)
+}
+
+/// An action the settings menu can dispatch to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsAction {
+    /// Toggle the startup auto-update check on/off.
+    ToggleAutoUpdateCheck,
+    /// Return to the main menu.
+    Back,
+}
+
+/// The fixed label for the settings-menu "back" entry.
+const SETTINGS_BACK_LABEL: &str = "Back to main menu";
+
+/// Builds the auto-update toggle's menu label, showing its current state. The
+/// label is dynamic (it reflects `enabled`) so it lives here rather than in a
+/// static table.
+pub fn auto_update_toggle_label(enabled: bool) -> String {
+    format!(
+        "Automatic update check: {} (select to toggle)",
+        if enabled { "enabled" } else { "disabled" }
+    )
+}
+
+/// The settings-menu labels, in display order, for the current config state.
+pub fn settings_menu_labels(config: &Config) -> Vec<String> {
+    vec![
+        auto_update_toggle_label(config.auto_update_check),
+        SETTINGS_BACK_LABEL.to_string(),
+    ]
+}
+
+/// Maps a selected settings-menu label back to its [`SettingsAction`].
+///
+/// The toggle label is dynamic (it carries the current state), so anything that
+/// is not the fixed back entry is treated as the toggle.
+pub fn dispatch_settings_menu(label: &str) -> SettingsAction {
+    if label == SETTINGS_BACK_LABEL {
+        SettingsAction::Back
+    } else {
+        SettingsAction::ToggleAutoUpdateCheck
+    }
 }
 
 /// One selectable operation in the operation-selection prompt: the display label
@@ -251,7 +299,7 @@ pub fn output_path(output_dir: &str, slug: &str, file_name: &str) -> PathBuf {
 /// recording returns here when it (and its post-recording menu) finishes, keeping
 /// menu and recording as separate phases. The loop exits on "Quit" or when the
 /// user cancels the menu prompt (Esc / Ctrl-C).
-pub fn run(config: &Config, client: &Client) -> Result<(), MenuError> {
+pub fn run(config: &mut Config, client: &Client) -> Result<(), MenuError> {
     let mut operations = match list_operations(client) {
         Ok(ops) => ops,
         Err(err) => {
@@ -278,8 +326,55 @@ pub fn run(config: &Config, client: &Client) -> Result<(), MenuError> {
                 }
                 Err(err) => eprintln!("Unable to retrieve operations list: {err}"),
             },
+            Some(MenuAction::Settings) => settings_menu(config)?,
             Some(MenuAction::Quit) => break,
             None => eprintln!("Unrecognized menu selection: {selection}"),
+        }
+    }
+
+    Ok(())
+}
+
+/// Runs the in-app settings menu, letting the user edit and persist
+/// configuration. Currently exposes a single toggle for the startup auto-update
+/// check (gh-104); each change is written back via [`Config::write`] so it
+/// survives the next launch.
+///
+/// MANUAL/TTY-ONLY: drives `inquire` select prompts; the toggle/dispatch logic
+/// it relies on ([`settings_menu_labels`], [`dispatch_settings_menu`]) is pure
+/// and unit-tested. Backing out (Esc / Ctrl-C) or "Back" returns to the caller.
+pub fn settings_menu(config: &mut Config) -> Result<(), MenuError> {
+    loop {
+        let labels = settings_menu_labels(config);
+        let selection = match tui::select("Settings", &labels) {
+            Ok(selection) => selection,
+            // Backing out of settings returns to the main menu, not an error.
+            Err(TuiError::Cancelled) | Err(TuiError::Interrupted) => break,
+            Err(err) => return Err(err.into()),
+        };
+
+        match dispatch_settings_menu(&selection) {
+            SettingsAction::ToggleAutoUpdateCheck => {
+                config.auto_update_check = !config.auto_update_check;
+                // Persist immediately so the choice survives a restart.
+                match config.write() {
+                    Ok(()) => println!(
+                        "Automatic update check {}.",
+                        if config.auto_update_check {
+                            "enabled"
+                        } else {
+                            "disabled"
+                        }
+                    ),
+                    Err(err) => {
+                        // Roll back the in-memory change so the menu keeps showing
+                        // the actual persisted state.
+                        config.auto_update_check = !config.auto_update_check;
+                        eprintln!("Failed to save configuration: {err}");
+                    }
+                }
+            }
+            SettingsAction::Back => break,
         }
     }
 
@@ -404,7 +499,10 @@ mod tests {
     #[test]
     fn main_menu_labels_match_items_in_order() {
         let labels = main_menu_labels();
-        assert_eq!(labels, ["Start recording", "Refresh operations", "Quit"]);
+        assert_eq!(
+            labels,
+            ["Start recording", "Refresh operations", "Settings", "Quit"]
+        );
     }
 
     #[test]
@@ -417,7 +515,57 @@ mod tests {
             dispatch_main_menu("Refresh operations"),
             Some(MenuAction::RefreshOperations)
         );
+        assert_eq!(dispatch_main_menu("Settings"), Some(MenuAction::Settings));
         assert_eq!(dispatch_main_menu("Quit"), Some(MenuAction::Quit));
+    }
+
+    // --- settings menu --------------------------------------------------------
+
+    #[test]
+    fn auto_update_toggle_label_reflects_state() {
+        assert!(auto_update_toggle_label(true).contains("enabled"));
+        assert!(auto_update_toggle_label(false).contains("disabled"));
+    }
+
+    #[test]
+    fn settings_menu_labels_lead_with_toggle_and_end_with_back() {
+        let mut cfg = Config::with_defaults();
+        let labels = settings_menu_labels(&cfg);
+        assert_eq!(labels[0], auto_update_toggle_label(true));
+        assert_eq!(labels.last().unwrap(), "Back to main menu");
+
+        cfg.auto_update_check = false;
+        let labels = settings_menu_labels(&cfg);
+        assert_eq!(labels[0], auto_update_toggle_label(false));
+    }
+
+    #[test]
+    fn dispatch_settings_menu_maps_back_and_toggle() {
+        assert_eq!(
+            dispatch_settings_menu("Back to main menu"),
+            SettingsAction::Back
+        );
+        // Either rendering of the dynamic toggle label maps to the toggle action.
+        assert_eq!(
+            dispatch_settings_menu(&auto_update_toggle_label(true)),
+            SettingsAction::ToggleAutoUpdateCheck
+        );
+        assert_eq!(
+            dispatch_settings_menu(&auto_update_toggle_label(false)),
+            SettingsAction::ToggleAutoUpdateCheck
+        );
+    }
+
+    #[test]
+    fn settings_toggle_label_round_trips_through_dispatch() {
+        // The label the prompt would show for each state dispatches to the toggle.
+        for enabled in [true, false] {
+            let label = auto_update_toggle_label(enabled);
+            assert_eq!(
+                dispatch_settings_menu(&label),
+                SettingsAction::ToggleAutoUpdateCheck
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds autoUpdateCheck config field (default ENABLED; absent-in-file stays enabled via ConfigFile Option overlay), gates the single notify_update() seam in app.rs (skip when disabled, no network), and a settings-menu toggle persisted via Config::write. Tests: default/absent/disabled/persisted + gate decision. Gates pass; review pass. Closes gh-104. Base: rust-rewrite.