### PR TITLE
Upgrade Rust edition to 2024 (aterm-8tn.18)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aterm"
 version = "0.0.0"
-edition = "2021"
-# MSRV: code uses Option::is_none_or (stabilized in 1.82).
-rust-version = "1.82"
+edition = "2024"
+# MSRV: edition 2024 requires Rust 1.85+.
+rust-version = "1.85"
 description = "ASHIRT terminal recorder (Rust rewrite)"
 license = "MIT"
 repository = "https://github.com/ashirt-ops/aterm"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2021"
+edition = "2024"

--- a/src/ashirt/http.rs
+++ b/src/ashirt/http.rs
@@ -17,10 +17,10 @@
 
 use std::time::{Duration, SystemTime};
 
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, DATE};
 use reqwest::Method;
-use serde::de::DeserializeOwned;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, DATE};
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use thiserror::Error;
 
 use super::signing::{self, Credentials, SigningError};

--- a/src/ashirt/signing.rs
+++ b/src/ashirt/signing.rs
@@ -22,8 +22,8 @@
 //!
 //! `secret_bytes` is the base64 decoding of the credential's secret key.
 
-use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::{Digest, Sha256};
 use thiserror::Error;

--- a/src/config.rs
+++ b/src/config.rs
@@ -322,7 +322,7 @@ fn read_config_file(path: &Path) -> Result<Option<ConfigFile>, ConfigError> {
             return Err(ConfigError::Read {
                 path: path.to_path_buf(),
                 source,
-            })
+            });
         }
     };
     serde_yaml_ng::from_str(&text)

--- a/src/config_setup.rs
+++ b/src/config_setup.rs
@@ -193,7 +193,7 @@ pub fn read_ashirt_import(path: &Path) -> Result<Option<AshirtImport>, ConfigErr
             return Err(ConfigError::Read {
                 path: path.to_path_buf(),
                 source,
-            })
+            });
         }
     };
     // An ASHIRT config that fails to parse is treated as "nothing to import"

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -37,9 +37,9 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 use crate::ashirt::http::{Client, HttpError};
-use crate::ashirt::ops_tags::{list_operations, Operation};
+use crate::ashirt::ops_tags::{Operation, list_operations};
 use crate::config::Config;
-use crate::recorder::{record_session, RecorderError};
+use crate::recorder::{RecorderError, record_session};
 use crate::tui::{self, TuiError};
 use crate::upload_menu;
 

--- a/src/playback.rs
+++ b/src/playback.rs
@@ -112,7 +112,7 @@ fn parse_event(line: &str) -> Result<Event, PlaybackError> {
         other => {
             return Err(PlaybackError::Parse(format!(
                 "unknown event code {other:?}: {line}"
-            )))
+            )));
         }
     };
 

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -37,7 +37,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 use thiserror::Error;
 
 use crate::asciicast::{CastError, Event, EventKind, Header, Writer};

--- a/src/recorder/unix.rs
+++ b/src/recorder/unix.rs
@@ -8,8 +8,8 @@
 //!     input-forwarding loop can notice the child exiting and stop promptly.
 
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use super::StdinRead;

--- a/src/upload_menu.rs
+++ b/src/upload_menu.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 use crate::ashirt::http::{Client, HttpError};
 use crate::ashirt::ops_tags::{self, Tag};
 use crate::ashirt::upload::{
-    upload_evidence, Evidence, UploadError, CONTENT_TYPE_TERMINAL_RECORDING,
+    CONTENT_TYPE_TERMINAL_RECORDING, Evidence, UploadError, upload_evidence,
 };
 use crate::tui::{self, TuiError};
 


### PR DESCRIPTION
Pure edition migration: edition=2024, rust-version=1.85, cargo fix --edition applied across all modules. No behavior change. Gates (default + --features playback): build/test/clippy -Dwarnings/fmt all pass. Base: rust-rewrite.