### PR TITLE
Remove stale entries from .gitignore (aterm-8tn.26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,14 +6,10 @@
 .vscode
 .idea
 
-# Private Files
-conf.yaml
-
 # Rust
 /target
 
 # Others
-cmd/aterm/aterm
 dist
 .env
 .tool-versions


### PR DESCRIPTION
Drops Go-era cmd/aterm/aterm and conf.yaml dev-ignore; keeps /target, dist, .env. .gitignore-only. Base: rust-rewrite.