### PR TITLE
Fix: default output_dir to home directory (aterm-8tn.27)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -157,12 +157,22 @@ struct ConfigFile {
 impl Config {
     /// Returns the built-in defaults — the lowest-precedence source.
     ///
-    /// Mirrors the Go `TermRecorderConfigWithDefaults`: schema version `1` and
-    /// the recording shell taken from the `SHELL` environment variable.
+    /// Mirrors the Go `TermRecorderConfigWithDefaults`: schema version `1`, the
+    /// recording shell taken from the `SHELL` environment variable, and the
+    /// output base defaulting to the user's home directory (matching the Go
+    /// `aterm` documented `outputDir` default).
     pub fn with_defaults() -> Self {
         Config {
             config_version: 1,
             recording_shell: std::env::var("SHELL").unwrap_or_default(),
+            // Base recordings under the user's home directory by default so a
+            // config with no file/CLI value still has a sensible, absolute
+            // output base. If the home dir cannot be determined (very unlikely),
+            // fall back to the empty string, which the file/CLI can still
+            // override.
+            output_dir: directories::BaseDirs::new()
+                .map(|b| b.home_dir().display().to_string())
+                .unwrap_or_default(),
             // Default ENABLED. The derived `Default` gives `false` for a bool, so
             // the enabled default lives here and is preserved by the file overlay
             // (absent in file => stays `true`).
@@ -554,6 +564,37 @@ mod tests {
     #[test]
     fn auto_update_check_defaults_enabled() {
         assert!(Config::with_defaults().auto_update_check);
+    }
+
+    /// The built-in default for `output_dir` is a non-empty, sensible base — the
+    /// user's home directory — so recordings have an output base even with no
+    /// file/CLI value. (CI/dev environments always have a resolvable home.)
+    #[test]
+    fn output_dir_defaults_to_home_dir() {
+        let home = directories::BaseDirs::new()
+            .map(|b| b.home_dir().display().to_string())
+            .expect("a home directory is resolvable in the test environment");
+        let cfg = Config::with_defaults();
+        assert!(!cfg.output_dir.is_empty(), "output_dir default must be set");
+        assert_eq!(
+            cfg.output_dir, home,
+            "output_dir default must be the home directory"
+        );
+    }
+
+    /// A config-file `outputDir` overrides the built-in home-directory default.
+    #[test]
+    fn output_dir_file_overrides_default() {
+        let path = temp_path("output-dir-override");
+        fs::write(&path, "outputDir: /tmp/custom-recordings\n").expect("write temp config");
+
+        let cfg = Config::load_from(&path, &empty_cli()).expect("load");
+        assert_eq!(
+            cfg.output_dir, "/tmp/custom-recordings",
+            "file outputDir must override the home-directory default"
+        );
+
+        fs::remove_file(&path).ok();
     }
 
     /// REQUIRED (serde gotcha): a config file that omits `autoUpdateCheck` must

--- a/src/config_setup.rs
+++ b/src/config_setup.rs
@@ -382,10 +382,13 @@ mod tests {
             output_dir: Some("/imported/dir".to_string()),
         };
 
-        // api_url already set: import must NOT clobber it. Others are empty and
-        // should be filled.
+        // api_url already set: import must NOT clobber it. The remaining fields
+        // are cleared so the "seed only empty fields" behaviour is exercised —
+        // note `with_defaults` now pre-fills `output_dir` with the home dir, so
+        // it is emptied here to test seeding into an empty field.
         let mut cfg = Config {
             api_url: "https://existing.example".to_string(),
+            output_dir: String::new(),
             ..Config::with_defaults()
         };
         import.seed_empty(&mut cfg);
@@ -447,12 +450,18 @@ mod tests {
         assert_eq!(soft.access_key, "saved-access");
         assert_eq!(soft.output_dir, "/saved/dir");
 
-        // Hard reset: existing ignored, back to defaults (empty creds).
+        // Hard reset: existing ignored, back to defaults (empty creds). The
+        // saved output_dir is dropped in favour of the built-in default (the
+        // home directory), not the saved "/saved/dir".
         let hard = wizard_seed(Some(&existing), true);
         assert!(hard.api_url.is_empty());
         assert!(hard.access_key.is_empty());
         assert!(hard.secret_key.is_empty());
-        assert!(hard.output_dir.is_empty());
+        assert_ne!(
+            hard.output_dir, "/saved/dir",
+            "hard reset drops the saved output_dir"
+        );
+        assert_eq!(hard.output_dir, Config::with_defaults().output_dir);
         assert_eq!(hard, Config::with_defaults());
     }
 


### PR DESCRIPTION
Config::with_defaults() now sets output_dir to the user home dir (was empty), matching Go's documented default; still overridable by file/CLI; tests assert default-is-home and file-overrides. Gates pass. Base: rust-rewrite.