### PR TITLE
Add macOS assertion for output_dir XDG data path (aterm-8tn.33)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -694,6 +694,22 @@ mod tests {
                 );
             }
         }
+
+        // On macOS the `directories` data dir is `Application Support`, but
+        // since .31 aterm's own `default_output_dir` uses the XDG data base
+        // (`$XDG_DATA_HOME` else `$HOME/.local/share`) — so the default also
+        // resolves to `~/.local/share/aterm`. Mirror the Linux assertion here.
+        // (Skip the literal check if the test environment injected an override.)
+        #[cfg(target_os = "macos")]
+        if std::env::var_os("XDG_DATA_HOME").is_none() {
+            assert!(
+                cfg.output_dir
+                    .replace('\\', "/")
+                    .ends_with(".local/share/aterm"),
+                "default must be ~/.local/share/aterm, got {}",
+                cfg.output_dir
+            );
+        }
     }
 
     /// A config-file `outputDir` overrides the built-in data-directory default.


### PR DESCRIPTION
Test-only: adds a #[cfg(target_os=macos)] assertion that output_dir defaults to ~/.local/share/aterm (honoring XDG_DATA_HOME), mirroring the Linux assertion and closing the Linux/macOS asymmetry. No production change. Verified by the macos-latest CI runner. Base: rust-rewrite.