### PR TITLE
Split ops_tags.rs into operations.rs and tags.rs (aterm-8tn.37)

### DIFF
--- a/README_developer.md
+++ b/README_developer.md
@@ -71,6 +71,6 @@ The upload flow is largely interactive CLI. The menus and prompt wrappers live
 in `src/upload_menu.rs`, `src/menu.rs`, and `src/tui.rs` (thin wrappers over the
 `inquire` prompt library). Talking to the ASHIRT backend — request signing,
 operations/tags lookups, and the multipart upload itself — lives under
-`src/ashirt/` (`http.rs`, `signing.rs`, `ops_tags.rs`, `upload.rs`).
+`src/ashirt/` (`http.rs`, `signing.rs`, `operations.rs`, `tags.rs`, `upload.rs`).
 
 [asciicast v3]: https://docs.asciinema.org/manual/asciicast/v3/

--- a/src/ashirt/mod.rs
+++ b/src/ashirt/mod.rs
@@ -3,10 +3,12 @@
 //! Split into focused submodules so downstream issues land independently:
 //!   * [`signing`]  — HMAC-SHA256 request signing (aterm-8tn.3)
 //!   * [`http`]     — blocking HTTP client base (aterm-8tn.8)
-//!   * [`upload`]   — multipart evidence upload
-//!   * [`ops_tags`] — operations + tags API
+//!   * [`upload`]     — multipart evidence upload
+//!   * [`operations`] — operations API
+//!   * [`tags`]       — tags API
 
 pub mod http;
-pub mod ops_tags;
+pub mod operations;
 pub mod signing;
+pub mod tags;
 pub mod upload;

--- a/src/ashirt/operations.rs
+++ b/src/ashirt/operations.rs
@@ -1,0 +1,108 @@
+//! ASHIRT operations API.
+//!
+//! Port of Go `network/get_operations.go`. Builds on the signed JSON helpers
+//! from [`crate::ashirt::http`]:
+//!   * [`list_operations`] — `GET /operations`
+//!
+//! Errors surface as [`HttpError`], the shared error type for the ASHIRT network
+//! layer; callers wrap it with `anyhow` at the application boundary.
+
+use serde::{Deserialize, Serialize};
+
+use super::http::{Client, HttpError};
+
+/// An ASHIRT operation, as returned by `GET /operations`.
+///
+/// Only the fields aterm consumes are modeled; serde ignores any additional
+/// fields the server may include, so the struct stays forward-compatible.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Operation {
+    /// URL-safe identifier used to address the operation in API paths.
+    pub slug: String,
+    /// Human-readable operation name.
+    pub name: String,
+    /// Numeric operation id. Defaulted when absent so partial payloads still
+    /// deserialize.
+    #[serde(default)]
+    pub id: i64,
+    /// Operation status code. Defaulted when absent.
+    #[serde(default)]
+    pub status: i64,
+    /// Number of users with access to the operation. Defaulted when absent.
+    #[serde(default, rename = "numUsers")]
+    pub num_users: i64,
+}
+
+/// Lists the operations visible to the authenticated user.
+pub fn list_operations(client: &Client) -> Result<Vec<Operation>, HttpError> {
+    client.get_json("/operations")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ashirt::signing::Credentials;
+    use httpmock::prelude::*;
+
+    fn test_creds() -> Credentials {
+        Credentials {
+            access_key: "test-access-key".to_string(),
+            // Valid base64; decodes to 24 bytes.
+            secret_key: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=".to_string(),
+        }
+    }
+
+    fn client_for(server: &MockServer) -> Client {
+        Client::new(server.base_url(), test_creds()).expect("client should build")
+    }
+
+    #[test]
+    fn list_operations_deserializes() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/api/operations")
+                .header_exists("Authorization")
+                .header_exists("Date");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!([
+                    { "slug": "s1", "name": "Jack", "numUsers": 1024, "status": 7, "id": 3 },
+                    { "slug": "s2", "name": "Jill", "numUsers": 2048, "status": 2, "id": 10 },
+                ]));
+        });
+
+        let client = client_for(&server);
+        let ops = list_operations(&client).expect("list operations should succeed");
+
+        mock.assert();
+        assert_eq!(ops.len(), 2);
+        assert_eq!(ops[0].slug, "s1");
+        assert_eq!(ops[0].name, "Jack");
+        assert_eq!(ops[0].id, 3);
+        assert_eq!(ops[0].status, 7);
+        assert_eq!(ops[0].num_users, 1024);
+        assert_eq!(ops[1].slug, "s2");
+        assert_eq!(ops[1].num_users, 2048);
+    }
+
+    #[test]
+    fn list_operations_tolerates_missing_optional_fields() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/api/operations");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!([{ "slug": "s1", "name": "Jack" }]));
+        });
+
+        let client = client_for(&server);
+        let ops = list_operations(&client).expect("minimal payload should deserialize");
+
+        mock.assert();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].slug, "s1");
+        assert_eq!(ops[0].id, 0);
+        assert_eq!(ops[0].num_users, 0);
+    }
+}

--- a/src/ashirt/tags.rs
+++ b/src/ashirt/tags.rs
@@ -1,8 +1,7 @@
-//! ASHIRT operations and tags API.
+//! ASHIRT tags API.
 //!
-//! Port of Go `network/get_operations.go` + `network/tagging.go`. Builds on the
-//! signed JSON helpers from [`crate::ashirt::http`]:
-//!   * [`list_operations`]  — `GET /operations`
+//! Port of Go `network/tagging.go`. Builds on the signed JSON helpers from
+//! [`crate::ashirt::http`]:
 //!   * [`list_tags`]        — `GET /operations/{slug}/tags`
 //!   * [`create_tag`]       — `POST /operations/{slug}/tags`
 //!   * [`random_tag_color`] — pick a color from the ASHIRT tag palette
@@ -16,28 +15,6 @@ use std::hash::{BuildHasher, Hasher};
 use serde::{Deserialize, Serialize};
 
 use super::http::{Client, HttpError};
-
-/// An ASHIRT operation, as returned by `GET /operations`.
-///
-/// Only the fields aterm consumes are modeled; serde ignores any additional
-/// fields the server may include, so the struct stays forward-compatible.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Operation {
-    /// URL-safe identifier used to address the operation in API paths.
-    pub slug: String,
-    /// Human-readable operation name.
-    pub name: String,
-    /// Numeric operation id. Defaulted when absent so partial payloads still
-    /// deserialize.
-    #[serde(default)]
-    pub id: i64,
-    /// Operation status code. Defaulted when absent.
-    #[serde(default)]
-    pub status: i64,
-    /// Number of users with access to the operation. Defaulted when absent.
-    #[serde(default, rename = "numUsers")]
-    pub num_users: i64,
-}
 
 /// A tag within an operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,11 +59,6 @@ const TAG_COLORS: &[&str] = &[
     "lightVermilion",
     "lightViolet",
 ];
-
-/// Lists the operations visible to the authenticated user.
-pub fn list_operations(client: &Client) -> Result<Vec<Operation>, HttpError> {
-    client.get_json("/operations")
-}
 
 /// Lists the tags defined for `operation_slug`.
 pub fn list_tags(client: &Client, operation_slug: &str) -> Result<Vec<Tag>, HttpError> {
@@ -133,56 +105,6 @@ mod tests {
 
     fn client_for(server: &MockServer) -> Client {
         Client::new(server.base_url(), test_creds()).expect("client should build")
-    }
-
-    #[test]
-    fn list_operations_deserializes() {
-        let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/api/operations")
-                .header_exists("Authorization")
-                .header_exists("Date");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(serde_json::json!([
-                    { "slug": "s1", "name": "Jack", "numUsers": 1024, "status": 7, "id": 3 },
-                    { "slug": "s2", "name": "Jill", "numUsers": 2048, "status": 2, "id": 10 },
-                ]));
-        });
-
-        let client = client_for(&server);
-        let ops = list_operations(&client).expect("list operations should succeed");
-
-        mock.assert();
-        assert_eq!(ops.len(), 2);
-        assert_eq!(ops[0].slug, "s1");
-        assert_eq!(ops[0].name, "Jack");
-        assert_eq!(ops[0].id, 3);
-        assert_eq!(ops[0].status, 7);
-        assert_eq!(ops[0].num_users, 1024);
-        assert_eq!(ops[1].slug, "s2");
-        assert_eq!(ops[1].num_users, 2048);
-    }
-
-    #[test]
-    fn list_operations_tolerates_missing_optional_fields() {
-        let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.method(GET).path("/api/operations");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(serde_json::json!([{ "slug": "s1", "name": "Jack" }]));
-        });
-
-        let client = client_for(&server);
-        let ops = list_operations(&client).expect("minimal payload should deserialize");
-
-        mock.assert();
-        assert_eq!(ops.len(), 1);
-        assert_eq!(ops[0].slug, "s1");
-        assert_eq!(ops[0].id, 0);
-        assert_eq!(ops[0].num_users, 0);
     }
 
     #[test]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -4,7 +4,7 @@
 //! recording-start path (`recording/start_recording.go`). It ties together the
 //! existing building blocks:
 //!   * [`crate::tui`] — the searchable-select menu primitive;
-//!   * [`crate::ashirt::ops_tags::list_operations`] — operation selection;
+//!   * [`crate::ashirt::operations::list_operations`] — operation selection;
 //!   * [`crate::config`] — output directory / file name / shell;
 //!   * [`crate::recorder::record_session`] — the actual recording.
 //!
@@ -37,7 +37,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 use crate::ashirt::http::{Client, HttpError};
-use crate::ashirt::ops_tags::{Operation, list_operations};
+use crate::ashirt::operations::{Operation, list_operations};
 use crate::config::Config;
 use crate::recorder::{RecorderError, record_session};
 use crate::tui::{self, TuiError};
@@ -380,7 +380,7 @@ pub fn resolve_output_file_name(configured: &str) -> String {
 ///
 /// The random suffix keeps concurrent / repeated recordings from colliding (the
 /// output file is created with `create_new`). Like
-/// [`crate::ashirt::ops_tags::random_tag_color`], this seeds off [`RandomState`]
+/// [`crate::ashirt::tags::random_tag_color`], this seeds off [`RandomState`]
 /// rather than pulling in the `rand` crate for a single value.
 pub fn default_output_file_name() -> String {
     let r = RandomState::new().build_hasher().finish();

--- a/src/upload_menu.rs
+++ b/src/upload_menu.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 use crate::ashirt::http::{Client, HttpError};
-use crate::ashirt::ops_tags::{self, Tag};
+use crate::ashirt::tags::{self, Tag};
 use crate::ashirt::upload::{
     CONTENT_TYPE_TERMINAL_RECORDING, Evidence, UploadError, upload_evidence,
 };
@@ -233,7 +233,7 @@ pub fn post_recording_menu(
 fn upload_flow(client: &Client, operation_slug: &str, path: &Path) -> Result<(), MenuError> {
     let description = tui::required_input("Description for this evidence")?;
 
-    let available = ops_tags::list_tags(client, operation_slug)?;
+    let available = tags::list_tags(client, operation_slug)?;
     let selected = tui::multiselect_indexed(
         "Select tags (space to toggle, enter to confirm)",
         &tag_options(&available),
@@ -242,8 +242,7 @@ fn upload_flow(client: &Client, operation_slug: &str, path: &Path) -> Result<(),
     let mut tag_ids = selected_tag_ids(&selected, &available);
     if wants_new_tag(&selected) {
         let name = tui::required_input("New tag name")?;
-        let created =
-            ops_tags::create_tag(client, operation_slug, &name, ops_tags::random_tag_color())?;
+        let created = tags::create_tag(client, operation_slug, &name, tags::random_tag_color())?;
         tag_ids.push(created.id);
     }
 


### PR DESCRIPTION
Pure refactor: splits src/ashirt/ops_tags.rs into operations.rs (Operation, list_operations) and tags.rs (Tag, NewTag, list_tags, create_tag, random_tag_color, TAG_COLORS); updates mod.rs and callers (menu.rs, upload_menu.rs). No behavior change. Gates green. Base: rust-rewrite.