### PR TITLE
Split release into tag-only release.yml; checkout@v6 (aterm-8tn.36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 # CI for the aterm Rust crate.
 #
-# Builds/tests/clippy/fmt across Linux/macOS/Windows, plus tag-triggered
-# release binaries. This is the only CI workflow; the legacy Go workflow was
-# removed when the Rust rewrite replaced the Go implementation.
+# Builds/tests/clippy/fmt across Linux/macOS/Windows. Tag-triggered release
+# binaries live in a separate workflow (.github/workflows/release.yml). The
+# legacy Go workflow was removed when the Rust rewrite replaced the Go
+# implementation.
 name: Rust CI
 
 on:
@@ -21,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install stable Rust toolchain
         shell: bash
@@ -40,51 +41,3 @@ jobs:
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
-
-  # Optimized release binaries for each OS, uploaded as workflow artifacts.
-  # Runs only on version tags (v*). Publishing these to a GitHub Release is
-  # handled separately once the rewrite is the shipping artifact.
-  release:
-    name: release binary (${{ matrix.os }})
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target_label: linux
-            bin: aterm
-          - os: macos-latest
-            target_label: macos
-            bin: aterm
-          - os: windows-latest
-            target_label: windows
-            bin: aterm.exe
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install stable Rust toolchain
-        shell: bash
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-
-      - name: Build release binary
-        run: cargo build --release --verbose
-
-      - name: Stage artifact
-        shell: bash
-        run: |
-          mkdir -p dist
-          cp "target/release/${{ matrix.bin }}" dist/
-          cp LICENSE dist/ 2>/dev/null || true
-          cp README.md dist/ 2>/dev/null || true
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: aterm-${{ github.ref_name }}-${{ matrix.target_label }}
-          path: dist
-          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+# Release workflow for the aterm Rust crate.
+#
+# Builds optimized release binaries for each OS and uploads them as workflow
+# artifacts. Runs only on version tags (v*); publishing these to a GitHub
+# Release is handled separately once the rewrite is the shipping artifact.
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: release binary (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target_label: linux
+            bin: aterm
+          - os: macos-latest
+            target_label: macos
+            bin: aterm
+          - os: windows-latest
+            target_label: windows
+            bin: aterm.exe
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install stable Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Build release binary
+        run: cargo build --release --verbose
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/release/${{ matrix.bin }}" dist/
+          cp LICENSE dist/ 2>/dev/null || true
+          cp README.md dist/ 2>/dev/null || true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: aterm-${{ github.ref_name }}-${{ matrix.target_label }}
+          path: dist
+          if-no-files-found: error


### PR DESCRIPTION
Moves the release job out of ci.yml into .github/workflows/release.yml (on: push tags v*), so it no longer appears as a broken skipped 'release binary (matrix.os)' check on push/PR. ci.yml keeps only build/test/lint. Bumps checkout to @v6 (latest) in both. First-party actions + pre-installed rustup. Base: rust-rewrite.