### PR TITLE
Platform-aware default shell + Windows recording input fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "signal-hook 0.4.4",
  "thiserror 2.0.18",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,14 @@ url = "2.5.8"
 rustix = { version = "1.1.4", features = ["event"] }
 signal-hook = "0.4.4"
 
+# Console VT input/output modes for ConPTY forwarding and clean stdin-reader
+# shutdown after recording; see src/recorder/windows.rs.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+    "Win32_System_IO",
+] }
+
 [dev-dependencies]
 httpmock = "0.8.3"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The config file follows the XDG standard and lives at
 | Config file key  | CLI flag                  | Meaning                                                            |
 | ---------------- | ------------------------- | ----------------------------------------------------------------- |
 | `outputDir`      |                           | Where to store recording files (defaults to the XDG data dir)     |
-| `recordingShell` | `-s`, `--shell`           | Shell to launch (defaults to `$SHELL`)                            |
+| `recordingShell` | `-s`, `--shell`           | Shell to launch (defaults to `$SHELL` on Unix, PowerShell on Windows) |
 | `operationSlug`  | `--operation`             | Operation to upload to (can also be selected before recording)    |
 | `apiURL`         |                           | Where the ASHIRT backend service is located                       |
 | `accessKey`      |                           | Access Key for the backend (created in the frontend)              |

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,13 +157,14 @@ struct ConfigFile {
 impl Config {
     /// Returns the built-in defaults — the lowest-precedence source.
     ///
-    /// Mirrors the Go `TermRecorderConfigWithDefaults`: schema version `1`, the
-    /// recording shell taken from the `SHELL` environment variable, and the
-    /// output base defaulting to aterm's per-user XDG data directory.
+    /// Mirrors the Go `TermRecorderConfigWithDefaults`: schema version `1`, a
+    /// platform-appropriate recording shell (see [`default_shell`] — `$SHELL` on
+    /// Unix, PowerShell on Windows), and the output base defaulting to aterm's
+    /// per-user XDG data directory.
     pub fn with_defaults() -> Self {
         Config {
             config_version: 1,
-            recording_shell: std::env::var("SHELL").unwrap_or_default(),
+            recording_shell: default_shell(),
             // Recordings are *data*, so base them under aterm's per-user XDG
             // data directory by default (`~/.local/share/aterm` on Linux,
             // honouring `$XDG_DATA_HOME`; the platform data dir on Windows;
@@ -456,6 +457,31 @@ fn default_output_dir() -> String {
         directories::BaseDirs::new()
             .map(|b| b.data_dir().join("aterm").display().to_string())
             .unwrap_or_default()
+    }
+}
+
+/// Returns the platform-appropriate default recording shell.
+///
+/// * Unix (Linux/macOS): the user's login shell from `$SHELL`, falling back to
+///   `/bin/sh` when it is unset or empty. This is what "pull whatever the
+///   `SHELL` environment variable is" means at configuration time.
+/// * Windows: PowerShell (`powershell.exe`). Windows has no `$SHELL`, and
+///   `%COMSPEC%` points at the legacy `cmd.exe`; PowerShell is the saner modern
+///   default and is present on supported Windows versions.
+///
+/// Always returns a non-empty value, so it doubles as the last-resort fallback
+/// when no shell is configured (see [`crate::menu`]).
+pub fn default_shell() -> String {
+    #[cfg(windows)]
+    {
+        "powershell.exe".to_string()
+    }
+    #[cfg(not(windows))]
+    {
+        match std::env::var("SHELL") {
+            Ok(shell) if !shell.trim().is_empty() => shell,
+            _ => "/bin/sh".to_string(),
+        }
     }
 }
 
@@ -801,6 +827,37 @@ mod tests {
 
         fs::remove_file(&path).ok();
         fs::remove_dir(&dir).ok();
+    }
+
+    /// The default shell is always a non-empty, platform-appropriate value, so
+    /// `with_defaults` never seeds an empty `recording_shell` and the menu
+    /// fallback always has something to launch.
+    #[test]
+    fn default_shell_is_non_empty_and_platform_appropriate() {
+        let shell = default_shell();
+        assert!(!shell.trim().is_empty(), "default shell must be non-empty");
+
+        #[cfg(windows)]
+        assert_eq!(
+            shell, "powershell.exe",
+            "Windows default shell must be PowerShell"
+        );
+
+        // On Unix the default is `$SHELL` when set, else `/bin/sh`.
+        #[cfg(not(windows))]
+        match std::env::var("SHELL") {
+            Ok(s) if !s.trim().is_empty() => assert_eq!(
+                shell, s,
+                "Unix default shell must come from $SHELL when set"
+            ),
+            _ => assert_eq!(
+                shell, "/bin/sh",
+                "Unix default shell must fall back to /bin/sh"
+            ),
+        }
+
+        // `with_defaults` seeds the same value.
+        assert_eq!(Config::with_defaults().recording_shell, shell);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,13 @@
 //!     `anyhow::Result` is used ONLY at the command boundary ([`app::run`] and
 //!     `main`). See [`config`] for a worked thiserror example and [`app`] for the
 //!     anyhow boundary.
-//!   * No `unsafe`: the crate is `#![forbid(unsafe_code)]`. Platform syscalls go
-//!     through safe wrappers (e.g. `rustix` on Unix).
-#![forbid(unsafe_code)]
+//!   * No `unsafe` by default: the crate is `#![deny(unsafe_code)]`. Platform
+//!     syscalls go through safe wrappers (e.g. `rustix` on Unix). The one
+//!     exception is the Windows console FFI in [`recorder::windows`] — VT
+//!     console-mode setup and cancelling the blocking stdin read — which has no
+//!     safe-wrapper equivalent and opts in via a scoped, documented
+//!     `#[allow(unsafe_code)]` on that module alone.
+#![deny(unsafe_code)]
 
 pub mod app;
 pub mod asciicast;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -666,17 +666,16 @@ fn start_recording(
     Ok(())
 }
 
-/// Picks the shell to record: the configured shell, falling back to `$SHELL`,
-/// then `/bin/sh`. The configured value is normally already seeded from `$SHELL`
-/// by [`Config::with_defaults`]; this keeps a sensible last resort.
+/// Picks the shell to record: the configured shell, falling back to the
+/// platform default ([`crate::config::default_shell`] — `$SHELL` on Unix,
+/// PowerShell on Windows). The configured value is normally already seeded with
+/// that same default by [`Config::with_defaults`]; this keeps a sensible last
+/// resort when the config carries an empty shell.
 fn recording_shell(config: &Config) -> String {
     if !config.recording_shell.trim().is_empty() {
         return config.recording_shell.clone();
     }
-    match std::env::var("SHELL") {
-        Ok(shell) if !shell.trim().is_empty() => shell,
-        _ => "/bin/sh".to_string(),
-    }
+    crate::config::default_shell()
 }
 
 #[cfg(test)]

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -131,6 +131,10 @@ impl PtySession {
             .map_err(|e| RecorderError::OpenPty(e.to_string()))?;
 
         let mut cmd = CommandBuilder::new(shell);
+        // Forward the current environment verbatim. `std::env::vars()` only yields
+        // variables that are actually set, so `TERM`/`SHELL` are passed through
+        // when present (e.g. a Git Bash / MSYS / WSL-interop launch) and simply
+        // absent otherwise — native Windows consoles define neither.
         for (key, value) in std::env::vars() {
             cmd.env(key, value);
         }
@@ -454,6 +458,11 @@ pub fn record_session<W: Write + Send + 'static>(
     // Raw mode is entered only after the PTY is up so an early failure leaves the
     // terminal untouched. The guard restores cooked mode on any exit path.
     let _raw = RawModeGuard::enable()?;
+    // Platform terminal-mode setup, restored on drop: on Windows this enables the
+    // console's virtual-terminal input/output so host key presses reach the
+    // ConPTY child as VT sequences and its VT output renders; on Unix it is a
+    // no-op (the PTY already does this). Dropped after teardown, before the menu.
+    let _term_mode = platform::TerminalModeGuard::install()?;
     let mut resize_watcher = platform::ResizeWatcher::install()?;
     let mut stdin_poller = platform::StdinPoller::new()?;
 

--- a/src/recorder/unix.rs
+++ b/src/recorder/unix.rs
@@ -18,9 +18,21 @@ use rustix::io::Errno;
 
 use super::StdinRead;
 
-/// Returns the user's preferred shell (`$SHELL`), falling back to `/bin/sh`.
-pub fn default_shell() -> String {
-    std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+/// No-op terminal-mode guard on Unix.
+///
+/// Unix PTYs already deliver raw VT input and render VT output without any extra
+/// console-mode setup, so the cooked-mode clearing done by the shared
+/// [`RawModeGuard`](super::RawModeGuard) is sufficient. This type exists only so
+/// the shared recorder can install platform terminal-mode setup uniformly; its
+/// Windows counterpart configures the console's virtual-terminal modes.
+#[must_use = "kept symmetric with the Windows guard; bind it to a variable"]
+pub struct TerminalModeGuard;
+
+impl TerminalModeGuard {
+    /// Installs nothing; succeeds unconditionally.
+    pub fn install() -> io::Result<Self> {
+        Ok(Self)
+    }
 }
 
 /// Detects terminal resizes via the `SIGWINCH` signal.

--- a/src/recorder/windows.rs
+++ b/src/recorder/windows.rs
@@ -4,23 +4,134 @@
 //! shared in [`super`] and runs over ConPTY (selected by `portable-pty`). On
 //! Windows there is no `SIGWINCH`, so:
 //!
+//!   * console VT modes are configured for the recording so host key presses are
+//!     forwarded to the ConPTY child as VT escape sequences and the child's VT
+//!     output renders correctly ([`TerminalModeGuard`]);
 //!   * resize detection polls the console size and emits a resize whenever it
 //!     changes ([`ResizeWatcher`]); the shared session then drives the ConPTY
 //!     resize;
 //!   * stdin is read on a dedicated thread feeding a channel ([`StdinPoller`]),
 //!     so the input-forwarding loop can poll with a timeout and react to the
 //!     child exiting rather than blocking on a console read.
+//!
+//! # `unsafe`
+//!
+//! The crate is otherwise `#![deny(unsafe_code)]`; this module is the single
+//! opt-out. The Windows console APIs used here — `GetStdHandle` /
+//! `GetConsoleMode` / `SetConsoleMode` for VT mode setup and `CancelSynchronousIo`
+//! to unblock the stdin reader on teardown — have no safe-wrapper equivalent (the
+//! way `rustix` covers the Unix syscalls), so each call is a small, individually
+//! justified `unsafe` block with a `SAFETY` comment.
+#![allow(unsafe_code)]
 
 use std::io::{self, Read};
+use std::os::windows::io::AsRawHandle;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
+
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Console::{
+    CONSOLE_MODE, DISABLE_NEWLINE_AUTO_RETURN, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT,
+    ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+    GetConsoleMode, GetStdHandle, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, SetConsoleMode,
+};
+use windows_sys::Win32::System::IO::CancelSynchronousIo;
 
 use super::StdinRead;
 
-/// Returns the user's shell. Honors `%COMSPEC%`, falling back to `cmd.exe`.
-pub fn default_shell() -> String {
-    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+/// Reads the console mode for `handle`, returning `None` when the handle is not
+/// a console (e.g. redirected stdin/stdout) so callers can no-op gracefully.
+fn console_mode(handle: HANDLE) -> Option<CONSOLE_MODE> {
+    let mut mode: CONSOLE_MODE = 0;
+    // SAFETY: `handle` comes from `GetStdHandle`; `GetConsoleMode` writes the
+    // current mode through the out-pointer and returns nonzero on success.
+    let ok = unsafe { GetConsoleMode(handle, &mut mode) };
+    (ok != 0).then_some(mode)
+}
+
+/// Best-effort `SetConsoleMode`; failures (e.g. redirected handles) are ignored.
+fn set_console_mode(handle: HANDLE, mode: CONSOLE_MODE) {
+    // SAFETY: `handle` comes from `GetStdHandle`; the call only reads `mode`.
+    unsafe {
+        let _ = SetConsoleMode(handle, mode);
+    }
+}
+
+/// Configures the host console's VT modes for the duration of a recording and
+/// restores the exact previous modes on drop.
+///
+/// Unlike crossterm's raw mode — which only *clears* the cooked-input flags and
+/// never touches the virtual-terminal flags — a ConPTY input forwarder must:
+///
+///   * **input:** enable `ENABLE_VIRTUAL_TERMINAL_INPUT` so the console encodes
+///     key presses (arrows, Ctrl-R, function keys, …) as the VT escape sequences
+///     the child shell expects. PowerShell/PSReadLine's line editor and
+///     reverse-search only work when those sequences arrive; without the flag
+///     the console delivers only typed characters and special keys are lost. The
+///     cooked-input flags are also cleared so the child — not our console — owns
+///     line editing and echo.
+///   * **output:** enable `ENABLE_VIRTUAL_TERMINAL_PROCESSING` so the child's VT
+///     output (colours, cursor motion) renders instead of printing escape bytes
+///     literally, plus `DISABLE_NEWLINE_AUTO_RETURN` to stop the console adding a
+///     carriage return at the right margin.
+///
+/// Restoring the captured modes on drop matters as much as setting them: the
+/// post-recording menu uses crossterm/inquire, which reads native key-event
+/// records rather than VT input, so leaving `ENABLE_VIRTUAL_TERMINAL_INPUT`
+/// enabled is what makes the menu's arrow keys misbehave afterwards.
+#[must_use = "console modes are restored when the guard is dropped; bind it to a variable"]
+pub struct TerminalModeGuard {
+    stdin: HANDLE,
+    stdout: HANDLE,
+    original_stdin: Option<CONSOLE_MODE>,
+    original_stdout: Option<CONSOLE_MODE>,
+}
+
+impl TerminalModeGuard {
+    /// Captures the current console modes and switches them into VT mode for
+    /// recording. Non-console handles are left untouched (and not restored).
+    pub fn install() -> io::Result<Self> {
+        // SAFETY: `GetStdHandle` returns this process's standard handles.
+        let stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+        let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+
+        let original_stdin = console_mode(stdin);
+        let original_stdout = console_mode(stdout);
+
+        if let Some(mode) = original_stdin {
+            let new = (mode & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT))
+                | ENABLE_VIRTUAL_TERMINAL_INPUT;
+            set_console_mode(stdin, new);
+        }
+
+        if let Some(mode) = original_stdout {
+            let new = mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
+            set_console_mode(stdout, new);
+        }
+
+        Ok(Self {
+            stdin,
+            stdout,
+            original_stdin,
+            original_stdout,
+        })
+    }
+}
+
+impl Drop for TerminalModeGuard {
+    fn drop(&mut self) {
+        // Best-effort restore of the exact modes captured at install; nothing is
+        // actionable if it fails and a Drop impl must not panic.
+        if let Some(mode) = self.original_stdin {
+            set_console_mode(self.stdin, mode);
+        }
+        if let Some(mode) = self.original_stdout {
+            set_console_mode(self.stdout, mode);
+        }
+    }
 }
 
 /// Detects terminal resizes by polling the console size.
@@ -56,36 +167,64 @@ impl ResizeWatcher {
 /// Console reads block until input arrives, so a background thread performs the
 /// blocking reads and forwards chunks over a channel; [`poll`](StdinPoller::poll)
 /// drains the channel with a timeout.
+///
+/// The thread is stopped and joined on drop (see [`Drop`]). This matters because
+/// a blocking console read left running past the end of a recording would steal
+/// the first keystroke aimed at the post-recording menu.
 pub struct StdinPoller {
     rx: Receiver<Vec<u8>>,
     leftover: Vec<u8>,
     eof: bool,
+    /// The reader thread, taken and joined in [`Drop`].
+    reader: Option<JoinHandle<()>>,
+    /// Raw handle of the reader thread, used to cancel its blocking read on drop.
+    thread: HANDLE,
+    /// Signals the reader thread to stop before/after its next read.
+    stop: Arc<AtomicBool>,
 }
 
 impl StdinPoller {
     /// Spawns the background stdin reader.
     pub fn new() -> io::Result<Self> {
         let (tx, rx) = mpsc::channel();
-        thread::spawn(move || {
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader_stop = Arc::clone(&stop);
+        let reader = thread::spawn(move || {
             let stdin = io::stdin();
             let mut lock = stdin.lock();
             let mut buf = [0u8; 8192];
             loop {
+                if reader_stop.load(Ordering::Relaxed) {
+                    break;
+                }
                 match lock.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
-                        if tx.send(buf[..n].to_vec()).is_err() {
+                        // If we were asked to stop while blocked in the read, or
+                        // the receiver is gone, drop this chunk and exit rather
+                        // than forward (and thereby consume) input meant for the
+                        // next phase.
+                        if reader_stop.load(Ordering::Relaxed)
+                            || tx.send(buf[..n].to_vec()).is_err()
+                        {
                             break;
                         }
                     }
+                    // A cancelled read (see `Drop`) surfaces as an error here too;
+                    // treat any read error as end-of-input.
                     Err(_) => break,
                 }
             }
         });
+        // Valid until we join the thread in `Drop`.
+        let thread = reader.as_raw_handle() as HANDLE;
         Ok(Self {
             rx,
             leftover: Vec::new(),
             eof: false,
+            reader: Some(reader),
+            thread,
+            stop,
         })
     }
 
@@ -110,5 +249,31 @@ impl StdinPoller {
         buf[..n].copy_from_slice(&self.leftover[..n]);
         self.leftover.drain(..n);
         Ok(StdinRead::Data(n))
+    }
+}
+
+impl Drop for StdinPoller {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(reader) = self.reader.take() {
+            // The reader thread is parked in a blocking console read. Cancel that
+            // read so the thread observes `stop` and exits promptly; otherwise it
+            // would survive to steal the first keystroke meant for the
+            // post-recording menu. The cancel can race the thread entering the
+            // read, so retry a bounded number of times until it finishes.
+            for _ in 0..40 {
+                if reader.is_finished() {
+                    break;
+                }
+                // SAFETY: `self.thread` is the reader thread's handle, valid until
+                // the join below. `CancelSynchronousIo` is a no-op (ERROR_NOT_FOUND)
+                // when no synchronous I/O is in flight.
+                unsafe {
+                    CancelSynchronousIo(self.thread);
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+            let _ = reader.join();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Platform-aware default recording shell.** `$SHELL` (→ `/bin/sh`) on Unix, **PowerShell** on Windows. Previously `Config::with_defaults()` read `$SHELL` on every platform, so on Windows it seeded an empty shell and fell back to `/bin/sh`, which doesn't exist there. Logic is centralized in `config::default_shell()` and shared by `with_defaults()` and the menu's runtime fallback; the unused per-platform `default_shell()` helpers in the recorder are removed.
- **Windows: forward special keys to the child.** The recorder relied only on crossterm raw mode, which clears the cooked-input flags but never sets `ENABLE_VIRTUAL_TERMINAL_INPUT` — so arrow keys / Ctrl-R were never encoded as the VT sequences PowerShell + PSReadLine need. New `TerminalModeGuard` enables VT input + VT output processing for the recording and restores the exact prior console modes on drop.
- **Windows: stop the orphaned stdin thread.** `StdinPoller` spawned a thread blocked in a console read and never stopped it, so after recording it stole the post-recording menu's first keystroke. It now cancels the blocking read (`CancelSynchronousIo`) and joins on drop.
- **`forbid(unsafe_code)` → `deny(unsafe_code)`.** The Windows console APIs have no safe-wrapper equivalent (the way `rustix` covers the Unix syscalls), so the crate-wide invariant is relaxed to `deny` with a single scoped, documented `#[allow(unsafe_code)]` on `recorder::windows` alone. Each FFI call has a `SAFETY` comment.
- Env forwarding into the child stays the verbatim environment — `TERM`/`SHELL` pass through when set and are absent otherwise (native Windows defines neither).

## Testing

- `cargo test` — 164 pass.
- `cargo clippy --all-targets` and `cargo clippy --target x86_64-pc-windows-gnu` — clean.
- ⚠️ The Windows code is compile-/clippy-verified via cross-check only. **Runtime behavior on Windows (especially the `CancelSynchronousIo` teardown timing) still needs on-device validation** — Windows can't be run in this environment.

## Notes

- The "Cannot load PSReadLine module" message users may see is most likely environmental (execution policy, PowerShell edition, module install) rather than something the recorder controls. If PSReadLine genuinely fails to *load*, Ctrl-R reverse search won't work even with correct input forwarding, since that's a PSReadLine feature.