### PR TITLE
Add timeout to GitHub update-check HTTP client

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -19,9 +19,16 @@
 //! considered. This mirrors the Go implementation it replaces.
 
 use std::fmt;
+use std::time::Duration;
 
 use serde::Deserialize;
 use thiserror::Error;
+
+/// Connection-establishment timeout for the update-check client.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+/// Overall per-request timeout so an unresponsive GitHub never hangs the update
+/// check forever. Mirrors the ASHIRT client in [`crate::ashirt::http`].
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Errors produced while checking for updates.
 #[derive(Debug, Error)]
@@ -226,7 +233,12 @@ pub fn fetch_release_tags(owner: &str, repo: &str) -> Result<Vec<String>, Update
     let url = format!("https://api.github.com/repos/{owner}/{repo}/releases");
     let user_agent = concat!("aterm/", env!("CARGO_PKG_VERSION"));
 
-    let releases: Vec<GithubRelease> = reqwest::blocking::Client::new()
+    let client = reqwest::blocking::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()?;
+
+    let releases: Vec<GithubRelease> = client
         .get(url)
         .header(reqwest::header::USER_AGENT, user_agent)
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")


### PR DESCRIPTION
## Summary

The ASHIRT API client already sets connect/request timeouts (`src/ashirt/http.rs`), but the GitHub release update check built a bare `reqwest::blocking::Client::new()` with no timeout, so an unresponsive `api.github.com` could hang the update check indefinitely.

This builds the update-check client with the same 10s connect / 30s request timeouts as the ASHIRT client.

## Context

This addresses **F-04 (CWE-400)**, originally raised against the pre-rewrite Go codebase in #142. That PR is stale (the Go code is gone after the Rust rewrite in #159); this reapplies the fix to the current Rust code.

While reviewing the other stale security PRs against the current codebase:
- **F-07** (#143, file permissions) and **F-08** (#145, rename path traversal) are already handled in the Rust rewrite, with test coverage.
- **F-06** (#146, URL-encode slug) is not a real issue under the actual threat model — the slug is server-provided in the normal flow and otherwise only sourced from the user's own config/CLI, so there's no trust boundary crossed.
- **F-05** (#141, response body size cap) is intentionally out of scope here; it's low-value defense-in-depth since the client only talks to its own authenticated ASHIRT server and GitHub's metadata API.

## Testing

`cargo build` clean; `cargo test` for the update module passes (21 tests).