### PR TITLE
Mask the secret key in --print-config, add --show-secrets opt-in (#205)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -122,7 +122,7 @@ pub fn run(cli: Cli) -> Result<()> {
     // `--print-config` prints the resolved config and exits, after validation and
     // the update notice (matching the Go ordering).
     if cli.print_config {
-        println!("{config}");
+        println!("{}", config.print_config(cli.show_secrets));
         return Ok(());
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,11 @@ pub struct Cli {
     #[arg(long = "print-config", visible_alias = "pc")]
     pub print_config: bool,
 
+    /// Include secret values (the API secret key) in `--print-config` output.
+    /// Off by default, so the secret is masked unless explicitly requested.
+    #[arg(long = "show-secrets")]
+    pub show_secrets: bool,
+
     /// Reset saved configuration (soft reset).
     #[arg(long = "reset")]
     pub reset: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -311,29 +311,53 @@ fn mask_secret(value: &str) -> &'static str {
     }
 }
 
-/// Human-readable rendering, mirroring the Go `PrintConfigTo` layout. This is
-/// for display only — use [`Config::to_yaml`] for serialization.
-impl fmt::Display for Config {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Current Configuration:")?;
-        writeln!(f, "\tConfig Version:  {}", self.config_version)?;
-        writeln!(f, "\tAPI Host:        {}", self.api_url)?;
-        writeln!(f, "\tOutput Base:     {}", self.output_dir)?;
-        // Credentials are masked: never echo the access/secret key values.
-        writeln!(f, "\tAccess Key:      {}", mask_secret(&self.access_key))?;
-        writeln!(f, "\tSecret Key:      {}", mask_secret(&self.secret_key))?;
-        writeln!(f, "\tOutput Prefix:   {}", self.output_file_name)?;
-        writeln!(f, "\tOperation Slug:  {}", self.operation_slug)?;
-        writeln!(f, "\tRecording Shell: {}", self.recording_shell)?;
-        write!(
-            f,
-            "\tUpdate Check:    {}",
+impl Config {
+    /// Renders the human-readable configuration, mirroring the Go
+    /// `PrintConfigTo` layout. The access key is always shown in full (it is an
+    /// identifier, not a secret); the secret key is shown in full only when
+    /// `show_secrets` is true, otherwise masked as `(set)`/`(not set)` so it is
+    /// never accidentally captured into recordings/scrollback.
+    pub fn print_config(&self, show_secrets: bool) -> String {
+        let secret = if show_secrets {
+            self.secret_key.as_str()
+        } else {
+            mask_secret(&self.secret_key)
+        };
+        format!(
+            "Current Configuration:\n\
+             \tConfig Version:  {}\n\
+             \tAPI Host:        {}\n\
+             \tOutput Base:     {}\n\
+             \tAccess Key:      {}\n\
+             \tSecret Key:      {}\n\
+             \tOutput Prefix:   {}\n\
+             \tOperation Slug:  {}\n\
+             \tRecording Shell: {}\n\
+             \tUpdate Check:    {}",
+            self.config_version,
+            self.api_url,
+            self.output_dir,
+            self.access_key,
+            secret,
+            self.output_file_name,
+            self.operation_slug,
+            self.recording_shell,
             if self.auto_update_check {
                 "enabled"
             } else {
                 "disabled"
-            }
+            },
         )
+    }
+}
+
+/// Human-readable rendering, mirroring the Go `PrintConfigTo` layout. This is
+/// for display only — use [`Config::to_yaml`] for serialization. The secret key
+/// is masked by default (the safe default for any accidental print); use
+/// [`Config::print_config`] with `show_secrets = true` to opt into cleartext.
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.print_config(false))
     }
 }
 
@@ -692,10 +716,11 @@ mod tests {
         fs::remove_file(&path).ok();
     }
 
-    /// The human-readable Display (used by `--print-config`) must never echo
-    /// the access/secret key values; they are masked as `(set)`/`(not set)`.
+    /// The default human-readable render (Display / `--print-config` without
+    /// `--show-secrets`) masks the SECRET key but prints the ACCESS key in full
+    /// (the access key is an identifier, not a secret).
     #[test]
-    fn display_masks_credentials() {
+    fn display_masks_secret_but_shows_access_key() {
         let cfg = Config {
             access_key: "AKIDEXAMPLE12345".to_string(),
             secret_key: "c2VjcmV0".to_string(),
@@ -703,31 +728,55 @@ mod tests {
         };
         let output = cfg.to_string();
 
-        // The actual credential values must be absent from the output.
+        // The secret value must be absent (masked).
         assert!(
             !output.contains(&cfg.secret_key),
-            "secret key value leaked in Display output"
+            "secret key value leaked in default Display output"
         );
-        assert!(
-            !output.contains(&cfg.access_key),
-            "access key value leaked in Display output"
-        );
-
-        // Both are shown as masked, since they are set.
-        assert!(output.contains("Access Key:      (set)"));
         assert!(output.contains("Secret Key:      (set)"));
+
+        // The access key is an identifier and prints in full.
+        assert!(
+            output.contains(&cfg.access_key),
+            "access key value should be shown in full"
+        );
+        assert!(output.contains("Access Key:      AKIDEXAMPLE12345"));
+
+        // `print_config(false)` matches Display exactly.
+        assert_eq!(output, cfg.print_config(false));
     }
 
-    /// Empty credentials render as `(not set)` rather than a blank value.
+    /// `print_config(true)` (the `--print-config --show-secrets` path) prints
+    /// the secret key value in cleartext.
     #[test]
-    fn display_masks_empty_credentials_as_not_set() {
+    fn print_config_with_show_secrets_reveals_secret() {
+        let cfg = Config {
+            access_key: "AKIDEXAMPLE12345".to_string(),
+            secret_key: "c2VjcmV0".to_string(),
+            ..Config::default()
+        };
+        let output = cfg.print_config(true);
+
+        assert!(
+            output.contains(&cfg.secret_key),
+            "secret key value should be present with show_secrets"
+        );
+        assert!(output.contains("Secret Key:      c2VjcmV0"));
+        // The masked marker must not be present when revealing.
+        assert!(!output.contains("Secret Key:      (set)"));
+    }
+
+    /// An empty secret renders as `(not set)` in the default (masked) render.
+    #[test]
+    fn display_masks_empty_secret_as_not_set() {
         let cfg = Config {
             access_key: String::new(),
             secret_key: String::new(),
             ..Config::default()
         };
         let output = cfg.to_string();
-        assert!(output.contains("Access Key:      (not set)"));
+        // Access key, shown in full, is empty here.
+        assert!(output.contains("Access Key:      \n"));
         assert!(output.contains("Secret Key:      (not set)"));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,6 +301,16 @@ impl Config {
     }
 }
 
+/// Renders a credential as `(set)`/`(not set)` so its value is never echoed,
+/// matching the masking style used by the in-app settings menu.
+fn mask_secret(value: &str) -> &'static str {
+    if value.is_empty() {
+        "(not set)"
+    } else {
+        "(set)"
+    }
+}
+
 /// Human-readable rendering, mirroring the Go `PrintConfigTo` layout. This is
 /// for display only — use [`Config::to_yaml`] for serialization.
 impl fmt::Display for Config {
@@ -309,8 +319,9 @@ impl fmt::Display for Config {
         writeln!(f, "\tConfig Version:  {}", self.config_version)?;
         writeln!(f, "\tAPI Host:        {}", self.api_url)?;
         writeln!(f, "\tOutput Base:     {}", self.output_dir)?;
-        writeln!(f, "\tAccess Key:      {}", self.access_key)?;
-        writeln!(f, "\tSecret Key:      {}", self.secret_key)?;
+        // Credentials are masked: never echo the access/secret key values.
+        writeln!(f, "\tAccess Key:      {}", mask_secret(&self.access_key))?;
+        writeln!(f, "\tSecret Key:      {}", mask_secret(&self.secret_key))?;
         writeln!(f, "\tOutput Prefix:   {}", self.output_file_name)?;
         writeln!(f, "\tOperation Slug:  {}", self.operation_slug)?;
         writeln!(f, "\tRecording Shell: {}", self.recording_shell)?;
@@ -679,6 +690,45 @@ mod tests {
         assert_eq!(original, read_back);
 
         fs::remove_file(&path).ok();
+    }
+
+    /// The human-readable Display (used by `--print-config`) must never echo
+    /// the access/secret key values; they are masked as `(set)`/`(not set)`.
+    #[test]
+    fn display_masks_credentials() {
+        let cfg = Config {
+            access_key: "AKIDEXAMPLE12345".to_string(),
+            secret_key: "c2VjcmV0".to_string(),
+            ..Config::default()
+        };
+        let output = cfg.to_string();
+
+        // The actual credential values must be absent from the output.
+        assert!(
+            !output.contains(&cfg.secret_key),
+            "secret key value leaked in Display output"
+        );
+        assert!(
+            !output.contains(&cfg.access_key),
+            "access key value leaked in Display output"
+        );
+
+        // Both are shown as masked, since they are set.
+        assert!(output.contains("Access Key:      (set)"));
+        assert!(output.contains("Secret Key:      (set)"));
+    }
+
+    /// Empty credentials render as `(not set)` rather than a blank value.
+    #[test]
+    fn display_masks_empty_credentials_as_not_set() {
+        let cfg = Config {
+            access_key: String::new(),
+            secret_key: String::new(),
+            ..Config::default()
+        };
+        let output = cfg.to_string();
+        assert!(output.contains("Access Key:      (not set)"));
+        assert!(output.contains("Secret Key:      (not set)"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #205.

## Problem
`Config`'s `Display` impl printed the ASHIRT API **secret key in cleartext**, and `--print-config` (`src/app.rs`) renders the config via `Display`. Running `aterm --print-config` inside a recorded shell would capture the secret into the `.cast` evidence and terminal scrollback (CWE-312 / CWE-532). The in-app settings menu already masks the secret; the two paths disagreed.

## Fix
- The **secret key** is now masked as `(set)` / `(not set)` by default. The render logic lives in `Config::print_config(show_secrets: bool) -> String`; `impl Display for Config` delegates to `print_config(false)`, so the **safe, masked output is the default** for any accidental print path.
- The **access key is printed in full** — it is an identifier, not a secret.
- Added an explicit opt-in flag **`--show-secrets`**: `aterm --print-config --show-secrets` prints the secret key in cleartext for the rare case the full value is wanted.

## Tests
- `display_masks_secret_but_shows_access_key`: secret VALUE absent (masked), access-key value present in full, and `Display == print_config(false)`.
- `print_config_with_show_secrets_reveals_secret`: with `show_secrets = true` the secret value IS present and the `(set)` marker is gone.
- `display_masks_empty_secret_as_not_set`: empty secret renders `(not set)`.
- `cli_definition_is_valid` (clap `debug_assert`) still passes.

## Verification (orchestrator-run)
- `cargo build`: exit 0, 0 warnings · `cargo clippy`: clean
- `cargo test`: exit 0 — 167 passed (164 baseline + 3)
- Confirmed: all 9 config fields still render; output is byte-identical to before except the masked secret.

## Reviewer note (out of scope, for follow-up)
`Config` and `Credentials` derive `Debug` with the cleartext secret. Safe today (nothing `{:?}`-prints them), but a manual masked `Debug` impl would be defense-in-depth against a future logging regression.

🤖 Generated as part of an orchestrated batch.