### PR TITLE
Use getrandom for filename/tag-color randomness (#207)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,13 +111,14 @@ dependencies = [
 
 [[package]]
 name = "aterm"
-version = "0.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "base64",
  "clap",
  "crossterm",
  "directories",
+ "getrandom 0.3.4",
  "hmac",
  "httpdate",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.22.1"
 clap = { version = "4.6.1", features = ["derive"] }
 crossterm = "0.29.0"
 directories = "6.0.0"
+getrandom = "0.3"
 hmac = "0.13.0"
 httpdate = "1.0.3"
 inquire = "0.9.4"

--- a/src/ashirt/tags.rs
+++ b/src/ashirt/tags.rs
@@ -9,9 +9,6 @@
 //! Errors surface as [`HttpError`], the shared error type for the ASHIRT network
 //! layer; callers wrap it with `anyhow` at the application boundary.
 
-use std::collections::hash_map::RandomState;
-use std::hash::{BuildHasher, Hasher};
-
 use serde::{Deserialize, Serialize};
 
 use super::http::{Client, HttpError};
@@ -80,11 +77,10 @@ pub fn create_tag(
 /// Returns a random color name from the ASHIRT tag palette.
 ///
 /// Port of Go `RandomTagColor`. Rather than pull in the `rand` crate for a
-/// single pick, this seeds off [`RandomState`], whose hash keys the standard
-/// library randomizes from the OS on each construction: building a hasher and
-/// reading its finished (empty-input) state yields a process-random `u64`.
+/// single pick, this draws a `u64` from [`crate::random::random_u64`] (a real OS
+/// randomness source) and reduces it into the palette index.
 pub fn random_tag_color() -> &'static str {
-    let r = RandomState::new().build_hasher().finish();
+    let r = crate::random::random_u64();
     let idx = (r % TAG_COLORS.len() as u64) as usize;
     TAG_COLORS[idx]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod cli;
 pub mod config;
 pub mod config_setup;
 pub mod menu;
+pub mod random;
 pub mod recorder;
 pub mod tui;
 pub mod update;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -28,9 +28,7 @@
 //! terminal. The interactive [`run`] entry point and [`start_recording`] wire
 //! those pure pieces into `tui`/`recorder` and are never exercised by tests.
 
-use std::collections::hash_map::RandomState;
 use std::fs::{self, File, OpenOptions};
-use std::hash::{BuildHasher, Hasher};
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 
@@ -380,10 +378,11 @@ pub fn resolve_output_file_name(configured: &str) -> String {
 ///
 /// The random suffix keeps concurrent / repeated recordings from colliding (the
 /// output file is created with `create_new`). Like
-/// [`crate::ashirt::tags::random_tag_color`], this seeds off [`RandomState`]
-/// rather than pulling in the `rand` crate for a single value.
+/// [`crate::ashirt::tags::random_tag_color`], this draws its value from
+/// [`crate::random::random_u64`] (a real OS randomness source) rather than
+/// pulling in the `rand` crate for a single value.
 pub fn default_output_file_name() -> String {
-    let r = RandomState::new().build_hasher().finish();
+    let r = crate::random::random_u64();
     format!("recording_{r:016x}.cast")
 }
 
@@ -999,10 +998,8 @@ mod tests {
         // Build a unique temp target using the same path layout the recorder
         // uses (<output_dir>/<slug>/<file>) so the test exercises the real
         // create-dir + create-file path.
-        let base = std::env::temp_dir().join(format!(
-            "aterm-perms-{:016x}",
-            RandomState::new().build_hasher().finish()
-        ));
+        let base =
+            std::env::temp_dir().join(format!("aterm-perms-{:016x}", crate::random::random_u64()));
         let path = output_path(
             base.to_str().expect("temp dir path is valid UTF-8"),
             "op-slug",

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,0 +1,23 @@
+//! Small shared randomness helper.
+//!
+//! Centralizes the project's one need for non-deterministic values — the random
+//! recording-file suffix ([`crate::menu::default_output_file_name`]) and the
+//! random tag color ([`crate::ashirt::tags::random_tag_color`]). Both previously
+//! derived a `u64` from `RandomState::new().build_hasher().finish()`, which
+//! relies on unspecified standard-library seeding behavior. This module pulls the
+//! value from `getrandom` instead, a real OS randomness source.
+
+/// Returns a random `u64` sourced from the operating system's randomness
+/// facility via [`getrandom`].
+///
+/// # Panics
+///
+/// Panics if the OS randomness source is unavailable. Both call sites use this
+/// for best-effort uniqueness (a file-name suffix and a cosmetic color), and a
+/// system with no working entropy source is not a state this tool can sensibly
+/// continue in, so failing loudly is preferable to silently degrading.
+pub fn random_u64() -> u64 {
+    let mut buf = [0u8; 8];
+    getrandom::fill(&mut buf).expect("OS randomness source (getrandom) unavailable");
+    u64::from_ne_bytes(buf)
+}


### PR DESCRIPTION
Fixes #207.

## Problem
Two call sites derived a `u64` from `RandomState::new().build_hasher().finish()` — `default_output_file_name` (`src/menu.rs`) and `random_tag_color` (`src/ashirt/tags.rs`). This relies on unspecified `std` `RandomState`/`DefaultHasher` seeding and its empty-input `finish()` value, neither of which is a stable contract. Fragile for a security-adjacent tool.

## Fix
- Added `getrandom = "0.3"` as a **direct** dependency (it was previously transitive-only) and a small shared helper `src/random.rs::random_u64()` backed by `getrandom::fill`.
- Replaced both production call sites (and the one test-only site) with the helper, and removed the now-unused `RandomState`/`BuildHasher`/`Hasher` imports.

## Verification (orchestrator-run)
- `cargo build`: exit 0, 0 warnings
- `cargo test`: exit 0 — 164 passed
- Reviewer confirmed: `getrandom::fill` is the correct 0.3 API; `random_u64` assembles all 8 bytes (full entropy, no truncation); both sites switched; no behavioral regression (hex/tag-index still valid).

## Note
The diff includes a `Cargo.lock` line where the `aterm` package version syncs `0.0.0 → 2.0.0`. This is a pre-existing discrepancy on `main` (Cargo.toml is already `2.0.0`); it rides along here only because this change legitimately must commit `Cargo.lock` to add getrandom.

🤖 Generated as part of an orchestrated batch.