### PR TITLE
Use a short timeout for the startup update check (#208)

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -24,11 +24,19 @@ use std::time::Duration;
 use serde::Deserialize;
 use thiserror::Error;
 
+// The update check is a best-effort, non-critical background notice that runs on
+// the startup path before the user's first interaction (see `app::run`). It must
+// not delay startup on a slow, captive, or offline network, so its timeouts are
+// kept deliberately short — failing fast and silently skipping the notice is far
+// better than making the user wait. These are intentionally much tighter than the
+// ASHIRT API client, whose requests are user-initiated and load-bearing.
+
 /// Connection-establishment timeout for the update-check client.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-/// Overall per-request timeout so an unresponsive GitHub never hangs the update
-/// check forever. Mirrors the ASHIRT client in [`crate::ashirt::http`].
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+/// Overall per-request timeout so an unresponsive GitHub never delays the user's
+/// first interaction. Short on purpose: this is a non-blocking-feel update notice,
+/// not a critical request.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// Errors produced while checking for updates.
 #[derive(Debug, Error)]


### PR DESCRIPTION
Fixes #208.

## Problem
`app::run` calls `notify_update()` synchronously before showing the menu / starting a recording, and the update HTTP client allowed a 10s connect + 30s overall timeout. On a slow, captive, or offline network the user could wait up to ~30s before they could begin recording.

## Fix (council-scoped: shorter timeout only)
- Reduced the update-check client timeouts in `src/update.rs`: connect 10s → **2s**, overall request 30s → **4s**, with a comment explaining this is a best-effort, non-critical background notice that must not delay the user's first interaction.
- Deliberately self-contained to `src/update.rs` — **no** thread spawning and **no** menu reordering (kept out of scope to stay independent of other in-flight changes touching `app.rs`/`menu.rs`).

## Verification (orchestrator-run)
- `cargo build`: exit 0, 0 warnings
- `cargo test`: exit 0 — 164 passed
- Reviewer confirmed the timeouts apply to the actual request client (`update.rs` builder + GET), and a timeout fails **gracefully**: `reqwest::Error` → `UpdateError::Request` → handled in `app.rs` as a single `eprintln!("Unable to check for updates: …")` line; startup then proceeds. No panic/unwrap on the network path. No stale 10s/30s remain.

## ⚠ Manual verification recommended
The non-blocking-startup improvement is a **timing property and is not unit-testable**. To confirm, run a versioned (non-`0.0.0`) build against a slow/unreachable GitHub and observe startup proceeds within ~4s worst case instead of ~30s. (Reviewer note: 2s/4s is sensible for normal links; mildly conservative on high-latency/satellite, an acceptable trade.)

🤖 Generated as part of an orchestrated batch.