### PR TITLE
Stamp recordings with a provenance comment line (#211)

### DIFF
--- a/src/asciicast.rs
+++ b/src/asciicast.rs
@@ -301,10 +301,15 @@ impl<W: Write> Writer<W> {
 
     /// Writes a comment line (`# <text>`). The header must already be written so
     /// that the first line of the stream is never a comment.
+    ///
+    /// Embedded newlines in `text` are stripped so a single call can never emit
+    /// more than one line (and thus never inject a non-comment line that a parser
+    /// would treat as an event).
     pub fn write_comment(&mut self, text: &str) -> Result<(), CastError> {
         if !self.header_written {
             return Err(CastError::HeaderNotWritten);
         }
+        let text = text.replace(['\n', '\r'], " ");
         writeln!(self.inner, "# {text}")?;
         Ok(())
     }
@@ -490,6 +495,23 @@ mod tests {
             "[0.5,\"o\",\"bye\"]\n",
         );
         assert_eq!(text, expected);
+    }
+
+    #[test]
+    fn write_comment_strips_embedded_newlines_into_one_line() {
+        // A comment with embedded newlines must not split into multiple lines
+        // (which could inject a line a parser treats as a non-comment event).
+        let mut buf = Vec::new();
+        {
+            let mut w = Writer::new(&mut buf, 0.0);
+            w.write_header(&Header::new(80, 24)).unwrap();
+            w.write_comment("recorded\nby\r\naterm").unwrap();
+        }
+        let text = String::from_utf8(buf).unwrap();
+        // Two lines total: header + a single comment line.
+        assert_eq!(text.lines().count(), 2);
+        let comment = text.lines().nth(1).unwrap();
+        assert_eq!(comment, "# recorded by  aterm");
     }
 
     #[test]

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -309,9 +309,15 @@ pub struct Recorder<W: Write> {
 impl<W: Write> Recorder<W> {
     /// Creates a recorder over `sink`, writing `header` immediately and starting
     /// the clock.
+    ///
+    /// A provenance comment (`# recorded by aterm <version>`) is emitted right
+    /// after the header so it is line 2 of every recording. Comments are not
+    /// events, so this does not advance the recording clock or affect interval
+    /// timing.
     pub fn start(sink: W, header: &Header) -> Result<Self, RecorderError> {
         let mut writer = Writer::new(sink, 0.0);
         writer.write_header(header)?;
+        writer.write_comment(concat!("recorded by aterm ", env!("CARGO_PKG_VERSION")))?;
         Ok(Self {
             writer,
             start: Instant::now(),
@@ -607,6 +613,12 @@ mod tests {
         assert_eq!(header["version"], 3);
         assert_eq!(header["term"]["cols"], 80);
 
+        // Line 2 is the provenance comment, not an event.
+        assert_eq!(
+            lines.next().unwrap(),
+            concat!("# recorded by aterm ", env!("CARGO_PKG_VERSION"))
+        );
+
         let out: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
         assert_eq!(out[0], 0.0);
         assert_eq!(out[1], "o");
@@ -623,6 +635,34 @@ mod tests {
         assert_eq!(exit[2], "0");
 
         assert!(lines.next().is_none());
+    }
+
+    #[test]
+    fn recorder_stamps_provenance_comment_as_line_two() {
+        // The live recording path must stamp every cast: header on line 1, the
+        // provenance comment on line 2, before any clock-stamped event.
+        let mut rec = Recorder::start(Vec::new(), &Header::new(80, 24)).unwrap();
+        rec.output(0.0, "hi").unwrap();
+        let bytes = rec.finish().unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        let mut lines = text.lines();
+
+        // Line 1 is the header (and must not be a comment).
+        let line1 = lines.next().unwrap();
+        assert!(!line1.starts_with('#'));
+        let header: Value = serde_json::from_str(line1).unwrap();
+        assert_eq!(header["version"], 3);
+
+        // Line 2 is the provenance comment with the crate version.
+        assert_eq!(
+            lines.next().unwrap(),
+            format!("# recorded by aterm {}", env!("CARGO_PKG_VERSION"))
+        );
+
+        // Line 3 is the first real event (proves the comment precedes events).
+        let event: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+        assert_eq!(event[1], "o");
+        assert_eq!(event[2], "hi");
     }
 
     #[test]
@@ -700,8 +740,14 @@ mod tests {
         let header: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
         assert_eq!(header["version"], 3);
 
+        // Line 2 is the provenance comment.
+        assert_eq!(
+            lines.next().unwrap(),
+            format!("# recorded by aterm {}", env!("CARGO_PKG_VERSION"))
+        );
+
         let events: Vec<Value> = lines
-            .filter(|l| !l.is_empty())
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
             .map(|l| serde_json::from_str(l).unwrap())
             .collect();
         assert!(


### PR DESCRIPTION
Fixes #211.

## What
Every recording now carries a provenance stamp as line 2: the header stays on line 1, followed immediately by `# recorded by aterm <version>` (from `env!("CARGO_PKG_VERSION")`), before any clock-stamped events.

This is a documented asciicast v3 feature (lines starting with `#` are comments and are ignored by players/parsers; the first line must not be a comment), so it is safe to add. It also gives the previously-unused `Writer::write_comment` a real caller.

## How
- Emit the comment inside `Recorder::start` (`src/recorder/mod.rs`) immediately after `write_header` and **before** the `Instant::now()` clock baseline. `write_comment` already enforces header-first (`CastError::HeaderNotWritten`), and it does **not** touch `last_time`, so timing intervals are unaffected. The single seam covers every recording (the `record_session` path goes through `Recorder::start`).
- Added a defensive newline guard in `write_comment` (`src/asciicast.rs`): `text.replace(['\n','\r'], " ")` so a comment can never span multiple lines / inject a fake event line. Harmless for the fixed literal, defensive for future dynamic text.

## Verification (orchestrator-run)
- `cargo build`: exit 0, 0 warnings
- `cargo test`: exit 0 — 166 passed (164 baseline + 2 new)
- Tests assert (on the **real Recorder path**, not just the writer API): line 1 is valid header JSON and not a comment, line 2 is `# recorded by aterm <version>`, line 3 is the first event (comment precedes events); plus a newline-guard test. Reviewer confirmed the clock is not advanced and the spec rule is preserved.

🤖 Generated as part of an orchestrated batch.